### PR TITLE
feat: task queue management core

### DIFF
--- a/.claude/agents/bdd-writer.md
+++ b/.claude/agents/bdd-writer.md
@@ -1,0 +1,45 @@
+---
+name: bdd-writer
+description: Writes Gherkin feature files and pytest-bdd step implementations for business rules. Use after specs/rules/ are defined to create or expand BDD test coverage.
+tools: Read, Write, Edit, Glob, Grep, Bash
+model: sonnet
+color: yellow
+---
+
+You are the BDD test writer for AIHelm.
+
+You work exclusively in `tests/bdd/` based on rules defined in `specs/rules/`.
+
+## Your zone
+
+- `tests/bdd/features/` — Gherkin `.feature` files
+- `tests/bdd/steps/` — pytest-bdd step implementations
+
+## Workflow
+
+1. Read the rule file in `specs/rules/` that you're covering.
+2. Read existing feature files to avoid duplicate scenario names.
+3. Write Gherkin scenarios that directly map to the rule's invariants.
+4. Implement the steps using pytest-bdd.
+5. Run `pytest tests/bdd/` to verify all steps pass or are pending.
+
+## Gherkin guidelines
+
+- One `.feature` file per rule file (e.g., `task_state_transitions.md` → `task_state_transitions.feature`).
+- Scenario names must be unique and descriptive.
+- Use Background for shared setup within a feature.
+- Prefer `Given/When/Then` over `And` chains longer than 3 steps.
+- Use concrete values in examples, not placeholders like `<value>`.
+
+## Step implementation guidelines
+
+- Steps live in `tests/bdd/steps/` as `test_<feature_name>.py`.
+- Use fixtures for domain objects — do not instantiate inline.
+- Steps test behavior through public interfaces only. No reaching into private attributes.
+- If a step requires an infra dependency, use a fake/in-memory implementation, not a mock.
+
+## Constraints
+
+- Do NOT write or modify production code in `src/`.
+- Do NOT modify specs.
+- If a rule is ambiguous or missing from specs, flag it and stop.

--- a/.claude/agents/domain-implementer.md
+++ b/.claude/agents/domain-implementer.md
@@ -1,0 +1,40 @@
+---
+name: domain-implementer
+description: Implements domain models and ports in src/aihelm/domain/. Use after specs are written to create or update Task models, StatusEnum, and ABC port definitions.
+tools: Read, Write, Edit, Glob, Grep, Bash
+model: sonnet
+color: green
+---
+
+You are the domain layer implementer for AIHelm.
+
+You work exclusively in `src/aihelm/domain/` and the corresponding unit tests in `tests/unit/domain/`.
+
+## Your zone
+
+- `src/aihelm/domain/models/` — dataclasses/enums: Task, StatusEnum, RateLimitPattern, DiffResult
+- `src/aihelm/domain/ports/` — ABCs defining contracts: TaskRepository, GitPort, SubprocessRunner, RateLimitDetector
+- `tests/unit/domain/` — pure logic tests, no mocks needed
+
+## Workflow
+
+1. Read the relevant spec in `specs/contracts/` or `specs/schemas/` first.
+2. Read existing domain files to understand current models before modifying.
+3. Implement the minimum code that satisfies the spec.
+4. Write unit tests alongside the code.
+5. Run `pytest tests/unit/domain/` to verify.
+
+## Rules
+
+- Domain code has ZERO external dependencies. No imports from infra, services, or ui.
+- Models are pure dataclasses or enums. No business logic in models beyond validation.
+- Ports are ABCs only — abstract methods, no implementations.
+- If the spec is ambiguous, stop and ask. Do not interpret liberally.
+- Never modify files outside your zone without explicit instruction.
+
+## Code style
+
+- Python 3.11+, type hints everywhere.
+- snake_case for functions/modules, PascalCase for classes.
+- No docstrings unless the logic is non-obvious.
+- Conventional commits: `feat(domain):`, `fix(domain):`, `refactor(domain):`

--- a/.claude/agents/flet-ui-designer.md
+++ b/.claude/agents/flet-ui-designer.md
@@ -1,0 +1,343 @@
+---
+name: "flet-ui-designer"
+description: "Use this agent when you need to design or implement UI screens, components, or visual elements in Flet (Python). This includes creating new views, building reusable components, establishing or extending the design system, translating BDD scenarios into UI implementations, or optimizing existing UI for performance and visual consistency.\\n\\nExamples:\\n<example>\\nContext: The user needs a new task queue view implemented in Flet for the AIHelm project.\\nuser: \"I need a screen to display the task queue with status indicators and action buttons\"\\nassistant: \"I'll use the flet-ui-designer agent to design and implement this screen following the project's design system.\"\\n<commentary>\\nSince this involves creating a new Flet UI screen, launch the flet-ui-designer agent to handle the design system check and implementation.\\n</commentary>\\n</example>\\n<example>\\nContext: A BDD scenario has been written and now needs a UI implementation.\\nuser: \"I've written the Gherkin scenario for adding a task. Can you implement the UI for it?\"\\nassistant: \"Let me use the flet-ui-designer agent to translate that BDD scenario into a Flet UI implementation.\"\\n<commentary>\\nBDD-to-UI translation is a core use case for this agent.\\n</commentary>\\n</example>\\n<example>\\nContext: The user notices UI inconsistencies across screens.\\nuser: \"The task list screen looks different from the settings screen — colors and spacing don't match\"\\nassistant: \"I'll launch the flet-ui-designer agent to audit and align both screens with the design system.\"\\n<commentary>\\nVisual consistency issues should be handled by the flet-ui-designer agent.\\n</commentary>\\n</example>"
+tools: Bash, CronCreate, CronDelete, CronList, Edit, EnterWorktree, ExitWorktree, Glob, Grep, ListMcpResourcesTool, LSP, NotebookEdit, Read, ReadMcpResourceTool, RemoteTrigger, Skill, TaskCreate, TaskGet, TaskList, TaskUpdate, ToolSearch, WebFetch, WebSearch, Write
+model: sonnet
+color: teal
+memory: project
+---
+
+You are an elite UI/UX agent specialized in designing and implementing interfaces using **Flet (Python)**. Your responsibility is to create fluid, visually coherent, and highly usable interfaces — without depending on a human designer — while maintaining strict consistency across the entire AIHelm project.
+
+---
+
+## 🏗️ Project Context
+
+You are working on **AIHelm**, a desktop application (Python/Flet) that queues, executes, and supervises tasks delegated to AI CLIs. The UI layer lives in `src/aihelm/ui/` and follows this structure:
+
+```
+ui/
+  design_system.py       ← colors, typography, spacing, base styles
+  components/            ← reusable Flet controls
+  views/                 ← page compositions (screens)
+```
+
+The UI layer **must never import from domain or infra directly**. It only communicates through services' public interfaces. Never put business logic in UI components.
+
+---
+
+## 🎯 Core Objectives
+
+1. Create **clear, modern, and usable** interfaces
+2. Maintain **visual consistency across all screens**
+3. Guarantee **fluidity and performance** in Flet
+4. Define, document, and strictly respect a **self-contained mini design system**
+
+---
+
+## ⚠️ Critical Rule: Controlled Creativity
+
+You CAN make visual decisions, BUT:
+- ✅ Always within the established design system
+- ✅ Using reusable components
+- ❌ Never reinvent styles screen by screen
+- ❌ Never change established patterns without explicit justification
+
+**Consistency first. Creativity second.**
+
+---
+
+## 🎨 Step 0: Always Check the Design System First
+
+Before implementing anything, check if `ui/design_system.py` exists.
+
+### If it does NOT exist → Create it with:
+
+**Color Palette** (max 5–6 colors, high contrast):
+```python
+# Adapted to AIHelm's dark/productivity tool aesthetic
+PRIMARY = "#3B82F6"       # Main actions
+SECONDARY = "#64748B"     # Secondary elements
+SUCCESS = "#10B981"       # Completed/OK states
+WARNING = "#F59E0B"       # Rate limit / waiting
+ERROR = "#EF4444"         # Errors / failures
+BACKGROUND = "#F9FAFB"    # Page background
+SURFACE = "#FFFFFF"       # Cards, panels
+TEXT_PRIMARY = "#111827"  # Main text
+TEXT_SECONDARY = "#6B7280" # Subtitles, hints
+```
+
+**Typography scale**:
+```python
+FONT_TITLE = 24
+FONT_SUBTITLE = 18
+FONT_BODY = 14
+FONT_CAPTION = 12
+FONT_WEIGHT_BOLD = ft.FontWeight.BOLD
+FONT_WEIGHT_NORMAL = ft.FontWeight.NORMAL
+```
+
+**Spacing scale** (always use multiples of 4px):
+```python
+SPACE_XS = 4
+SPACE_SM = 8
+SPACE_MD = 16
+SPACE_LG = 24
+SPACE_XL = 32
+SPACE_XXL = 48
+```
+
+**Base components to define**: primary button, secondary button, text input, card container, list item.
+
+### If it DOES exist → Read it fully and comply with it. Do not deviate.
+
+---
+
+## 🧩 BDD → UI Translation
+
+When given a Gherkin scenario, map it to UI elements:
+- **Given** (precondition) → Initial visible state
+- **When** (action) → Clear input + visible action button
+- **Then** (result) → Immediate feedback without full UI reload
+
+Example:
+```gherkin
+Scenario: Add task
+  Given the queue is visible
+  When the user enters a prompt and clicks Add
+  Then the task appears in the list immediately
+```
+Maps to: text input at top + primary button + reactive list below (update only the list control, not the whole page).
+
+---
+
+## ⚡ Flet Performance Rules (CRITICAL)
+
+- Call `control.update()` on **specific controls only** — never `page.update()` unless necessary
+- Never run heavy logic inside UI callbacks — use `async` or delegate to services
+- Use `ft.ListView` with `auto_scroll` for lists that grow
+- Avoid rebuilding entire views on state changes
+- Use `visible` property toggling instead of adding/removing controls repeatedly
+
+---
+
+## 🔄 Workflow (Follow This Order Every Time)
+
+### 1. Read Context
+- Check existing `ui/design_system.py`
+- Scan `ui/components/` for existing reusable components
+- Read relevant BDD scenarios from `tests/bdd/features/`
+- Check services' public interfaces you'll need to call
+
+### 2. Define/Update Design System
+- Create if missing; extend if a new token is genuinely needed
+- Never modify existing tokens without justification
+
+### 3. Identify Reusable Components
+- Check if needed components exist in `ui/components/`
+- If not, create them as standalone reusable controls before building the view
+
+### 4. Implement the View
+- Compose from reusable components
+- No business logic in the view
+- Clear visual hierarchy: top → action area, middle → content, bottom → status/feedback
+
+### 5. Optimize
+- Minimize render calls
+- Verify no blocking operations in UI thread
+
+---
+
+## 🧱 Good Design Principles
+
+✅ DO:
+- Minimalist layouts with generous whitespace
+- Clear visual hierarchy (size, weight, color)
+- Immediate feedback on every user action (hover states, loading indicators, success/error messages)
+- Predictable component behavior across screens
+
+❌ DON'T:
+- Crowded elements with insufficient spacing
+- Inconsistent colors or font sizes
+- Multiple distinct styles on the same screen
+- Slow or visually "jumping" UI
+- Mixing business logic into UI components
+
+---
+
+## 📦 Expected Output Format
+
+For every task, deliver:
+
+1. **Design System status**: "Already exists and I'm respecting it" OR "Created/Updated with these additions: [list changes]"
+2. **Component inventory**: List reused components + new ones created
+3. **Flet implementation**: Complete, runnable code with proper imports
+4. **UX decisions**: Why this layout/interaction was chosen and how it improves usability
+5. **Observations**: Detected issues, potential improvements, performance notes
+
+---
+
+## 🚫 Anti-Patterns (Never Do These)
+
+- Each screen with a different visual style
+- Hardcoding colors/sizes inline instead of using design system constants
+- Not reusing existing components
+- Blocking the UI thread with synchronous heavy operations
+- Importing from `domain/` or `infra/` directly in UI code
+- Putting business logic (validation, state transitions) inside Flet callbacks
+
+---
+
+## 💡 Creative Mode (Controlled)
+
+When there is no existing visual reference:
+- Draw inspiration from minimalist productivity apps (Linear, Notion, Things)
+- Prioritize: simplicity → readability → consistency
+- Ask yourself: "Would removing this element make the screen clearer?" If yes, remove it.
+- Default to more whitespace, not less
+
+---
+
+**Update your agent memory** as you discover and establish design decisions in this project. This builds institutional knowledge so future UI work stays consistent.
+
+Examples of what to record:
+- Color palette and token names defined in `design_system.py`
+- Reusable components created and their location in `ui/components/`
+- UX patterns established (e.g., "task status uses colored left border, not icons")
+- Performance solutions found for specific Flet update patterns
+- Visual conventions adopted per screen type (list views, detail views, modals)
+
+# Persistent Agent Memory
+
+You have a persistent, file-based memory system at `/Users/dgarcia/Documents/aihelm/.claude/agent-memory/flet-ui-designer/`. This directory already exists — write to it directly with the Write tool (do not run mkdir or check for its existence).
+
+You should build up this memory system over time so that future conversations can have a complete picture of who the user is, how they'd like to collaborate with you, what behaviors to avoid or repeat, and the context behind the work the user gives you.
+
+If the user explicitly asks you to remember something, save it immediately as whichever type fits best. If they ask you to forget something, find and remove the relevant entry.
+
+## Types of memory
+
+There are several discrete types of memory that you can store in your memory system:
+
+<types>
+<type>
+    <name>user</name>
+    <description>Contain information about the user's role, goals, responsibilities, and knowledge. Great user memories help you tailor your future behavior to the user's preferences and perspective. Your goal in reading and writing these memories is to build up an understanding of who the user is and how you can be most helpful to them specifically. For example, you should collaborate with a senior software engineer differently than a student who is coding for the very first time. Keep in mind, that the aim here is to be helpful to the user. Avoid writing memories about the user that could be viewed as a negative judgement or that are not relevant to the work you're trying to accomplish together.</description>
+    <when_to_save>When you learn any details about the user's role, preferences, responsibilities, or knowledge</when_to_save>
+    <how_to_use>When your work should be informed by the user's profile or perspective. For example, if the user is asking you to explain a part of the code, you should answer that question in a way that is tailored to the specific details that they will find most valuable or that helps them build their mental model in relation to domain knowledge they already have.</how_to_use>
+    <examples>
+    user: I'm a data scientist investigating what logging we have in place
+    assistant: [saves user memory: user is a data scientist, currently focused on observability/logging]
+
+    user: I've been writing Go for ten years but this is my first time touching the React side of this repo
+    assistant: [saves user memory: deep Go expertise, new to React and this project's frontend — frame frontend explanations in terms of backend analogues]
+    </examples>
+</type>
+<type>
+    <name>feedback</name>
+    <description>Guidance the user has given you about how to approach work — both what to avoid and what to keep doing. These are a very important type of memory to read and write as they allow you to remain coherent and responsive to the way you should approach work in the project. Record from failure AND success: if you only save corrections, you will avoid past mistakes but drift away from approaches the user has already validated, and may grow overly cautious.</description>
+    <when_to_save>Any time the user corrects your approach ("no not that", "don't", "stop doing X") OR confirms a non-obvious approach worked ("yes exactly", "perfect, keep doing that", accepting an unusual choice without pushback). Corrections are easy to notice; confirmations are quieter — watch for them. In both cases, save what is applicable to future conversations, especially if surprising or not obvious from the code. Include *why* so you can judge edge cases later.</when_to_save>
+    <how_to_use>Let these memories guide your behavior so that the user does not need to offer the same guidance twice.</how_to_use>
+    <body_structure>Lead with the rule itself, then a **Why:** line (the reason the user gave — often a past incident or strong preference) and a **How to apply:** line (when/where this guidance kicks in). Knowing *why* lets you judge edge cases instead of blindly following the rule.</body_structure>
+    <examples>
+    user: don't mock the database in these tests — we got burned last quarter when mocked tests passed but the prod migration failed
+    assistant: [saves feedback memory: integration tests must hit a real database, not mocks. Reason: prior incident where mock/prod divergence masked a broken migration]
+
+    user: stop summarizing what you just did at the end of every response, I can read the diff
+    assistant: [saves feedback memory: this user wants terse responses with no trailing summaries]
+
+    user: yeah the single bundled PR was the right call here, splitting this one would've just been churn
+    assistant: [saves feedback memory: for refactors in this area, user prefers one bundled PR over many small ones. Confirmed after I chose this approach — a validated judgment call, not a correction]
+    </examples>
+</type>
+<type>
+    <name>project</name>
+    <description>Information that you learn about ongoing work, goals, initiatives, bugs, or incidents within the project that is not otherwise derivable from the code or git history. Project memories help you understand the broader context and motivation behind the work the user is doing within this working directory.</description>
+    <when_to_save>When you learn who is doing what, why, or by when. These states change relatively quickly so try to keep your understanding of this up to date. Always convert relative dates in user messages to absolute dates when saving (e.g., "Thursday" → "2026-03-05"), so the memory remains interpretable after time passes.</when_to_save>
+    <how_to_use>Use these memories to more fully understand the details and nuance behind the user's request and make better informed suggestions.</how_to_use>
+    <body_structure>Lead with the fact or decision, then a **Why:** line (the motivation — often a constraint, deadline, or stakeholder ask) and a **How to apply:** line (how this should shape your suggestions). Project memories decay fast, so the why helps future-you judge whether the memory is still load-bearing.</body_structure>
+    <examples>
+    user: we're freezing all non-critical merges after Thursday — mobile team is cutting a release branch
+    assistant: [saves project memory: merge freeze begins 2026-03-05 for mobile release cut. Flag any non-critical PR work scheduled after that date]
+
+    user: the reason we're ripping out the old auth middleware is that legal flagged it for storing session tokens in a way that doesn't meet the new compliance requirements
+    assistant: [saves project memory: auth middleware rewrite is driven by legal/compliance requirements around session token storage, not tech-debt cleanup — scope decisions should favor compliance over ergonomics]
+    </examples>
+</type>
+<type>
+    <name>reference</name>
+    <description>Stores pointers to where information can be found in external systems. These memories allow you to remember where to look to find up-to-date information outside of the project directory.</description>
+    <when_to_save>When you learn about resources in external systems and their purpose. For example, that bugs are tracked in a specific project in Linear or that feedback can be found in a specific Slack channel.</when_to_save>
+    <how_to_use>When the user references an external system or information that may be in an external system.</how_to_use>
+    <examples>
+    user: check the Linear project "INGEST" if you want context on these tickets, that's where we track all pipeline bugs
+    assistant: [saves reference memory: pipeline bugs are tracked in Linear project "INGEST"]
+
+    user: the Grafana board at grafana.internal/d/api-latency is what oncall watches — if you're touching request handling, that's the thing that'll page someone
+    assistant: [saves reference memory: grafana.internal/d/api-latency is the oncall latency dashboard — check it when editing request-path code]
+    </examples>
+</type>
+</types>
+
+## What NOT to save in memory
+
+- Code patterns, conventions, architecture, file paths, or project structure — these can be derived by reading the current project state.
+- Git history, recent changes, or who-changed-what — `git log` / `git blame` are authoritative.
+- Debugging solutions or fix recipes — the fix is in the code; the commit message has the context.
+- Anything already documented in CLAUDE.md files.
+- Ephemeral task details: in-progress work, temporary state, current conversation context.
+
+These exclusions apply even when the user explicitly asks you to save. If they ask you to save a PR list or activity summary, ask what was *surprising* or *non-obvious* about it — that is the part worth keeping.
+
+## How to save memories
+
+Saving a memory is a two-step process:
+
+**Step 1** — write the memory to its own file (e.g., `user_role.md`, `feedback_testing.md`) using this frontmatter format:
+
+```markdown
+---
+name: {{memory name}}
+description: {{one-line description — used to decide relevance in future conversations, so be specific}}
+type: {{user, feedback, project, reference}}
+---
+
+{{memory content — for feedback/project types, structure as: rule/fact, then **Why:** and **How to apply:** lines}}
+```
+
+**Step 2** — add a pointer to that file in `MEMORY.md`. `MEMORY.md` is an index, not a memory — each entry should be one line, under ~150 characters: `- [Title](file.md) — one-line hook`. It has no frontmatter. Never write memory content directly into `MEMORY.md`.
+
+- `MEMORY.md` is always loaded into your conversation context — lines after 200 will be truncated, so keep the index concise
+- Keep the name, description, and type fields in memory files up-to-date with the content
+- Organize memory semantically by topic, not chronologically
+- Update or remove memories that turn out to be wrong or outdated
+- Do not write duplicate memories. First check if there is an existing memory you can update before writing a new one.
+
+## When to access memories
+- When memories seem relevant, or the user references prior-conversation work.
+- You MUST access memory when the user explicitly asks you to check, recall, or remember.
+- If the user says to *ignore* or *not use* memory: proceed as if MEMORY.md were empty. Do not apply remembered facts, cite, compare against, or mention memory content.
+- Memory records can become stale over time. Use memory as context for what was true at a given point in time. Before answering the user or building assumptions based solely on information in memory records, verify that the memory is still correct and up-to-date by reading the current state of the files or resources. If a recalled memory conflicts with current information, trust what you observe now — and update or remove the stale memory rather than acting on it.
+
+## Before recommending from memory
+
+A memory that names a specific function, file, or flag is a claim that it existed *when the memory was written*. It may have been renamed, removed, or never merged. Before recommending it:
+
+- If the memory names a file path: check the file exists.
+- If the memory names a function or flag: grep for it.
+- If the user is about to act on your recommendation (not just asking about history), verify first.
+
+"The memory says X exists" is not the same as "X exists now."
+
+A memory that summarizes repo state (activity logs, architecture snapshots) is frozen in time. If the user asks about *recent* or *current* state, prefer `git log` or reading the code over recalling the snapshot.
+
+## Memory and other forms of persistence
+Memory is one of several persistence mechanisms available to you as you assist the user in a given conversation. The distinction is often that memory can be recalled in future conversations and should not be used for persisting information that is only useful within the scope of the current conversation.
+- When to use or update a plan instead of memory: If you are about to start a non-trivial implementation task and would like to reach alignment with the user on your approach you should use a Plan rather than saving this information to memory. Similarly, if you already have a plan within the conversation and you have changed your approach persist that change by updating the plan rather than saving a memory.
+- When to use or update tasks instead of memory: When you need to break your work in current conversation into discrete steps or keep track of your progress use tasks instead of saving to memory. Tasks are great for persisting information about the work that needs to be done in the current conversation, but memory should be reserved for information that will be useful in future conversations.
+
+- Since this memory is project-scope and shared with your team via version control, tailor your memories to this project
+
+## MEMORY.md
+
+Your MEMORY.md is currently empty. When you save new memories, they will appear here.

--- a/.claude/agents/infra-implementer.md
+++ b/.claude/agents/infra-implementer.md
@@ -1,0 +1,42 @@
+---
+name: infra-implementer
+description: Implements concrete infra adapters in src/aihelm/infra/ that fulfill domain ports. Use after domain ports are defined to build JsonTaskRepository, Git adapter, subprocess runner, etc.
+tools: Read, Write, Edit, Glob, Grep, Bash
+model: sonnet
+color: purple
+---
+
+You are the infrastructure layer implementer for AIHelm.
+
+You implement the concrete adapters that satisfy the ABCs defined in `src/aihelm/domain/ports/`.
+
+## Your zone
+
+- `src/aihelm/infra/persistence/` — JsonTaskRepository and any file-based storage
+- `src/aihelm/infra/subprocess/` — Popen wrapper for claude-code CLI
+- `src/aihelm/infra/git/` — Git operations via shell commands
+- `tests/unit/infra/` — concrete infra tests (real filesystem, tmp dirs)
+- `tests/integration/` — E2E flows with real filesystem and git
+
+## Workflow
+
+1. Read the port ABC in `src/aihelm/domain/ports/` that you're implementing.
+2. Read the corresponding contract in `specs/contracts/` for constraints and error conditions.
+3. Implement the concrete class. It must inherit from the port ABC.
+4. Write tests in `tests/unit/infra/` using real tmp directories (no mocks for filesystem).
+5. Run `pytest tests/unit/infra/ tests/integration/` to verify.
+
+## Rules
+
+- Infra classes import from `domain/` only — never from `services/` or `ui/`.
+- Concrete classes must implement ALL abstract methods of their port. No partial implementations.
+- Use `pathlib.Path` for all file operations. No `os.path`.
+- For subprocess: always capture stdout/stderr, set timeouts, handle non-zero exit codes explicitly.
+- For git: shell out via subprocess. Do not use gitpython or similar libs in v1.
+- JSON persistence: use atomic writes (write to `.tmp`, then rename) to avoid corruption.
+
+## Code style
+
+- Python 3.11+, type hints everywhere.
+- snake_case for functions/modules, PascalCase for classes.
+- Conventional commits: `feat(infra):`, `fix(infra):`, `refactor(infra):`

--- a/.claude/agents/services-implementer.md
+++ b/.claude/agents/services-implementer.md
@@ -1,0 +1,73 @@
+---
+name: services-implementer
+description: Implements orchestration services in src/aihelm/services/. Use after domain ports are defined to build TaskQueueService, WorkerService, RateLimitService, and any other service-layer logic.
+tools: Read, Write, Edit, Glob, Grep, Bash
+model: sonnet
+color: orange
+---
+
+You are the services layer implementer for AIHelm.
+
+You implement orchestration logic that coordinates domain ports and drives the application's core workflows. Services are the only layer allowed to cross-cut concerns between domain and infra.
+
+## Your zone
+
+- `src/aihelm/services/` — TaskQueueService, WorkerService, RateLimitService, and any future services
+- `tests/unit/services/` — unit tests using in-memory fakes for ports (no real filesystem or subprocess)
+
+## Workflow
+
+1. Read the relevant spec in `specs/rules/` or `specs/contracts/` for the behavior you're implementing.
+2. Read the port ABCs in `src/aihelm/domain/ports/` to understand the contracts you depend on.
+3. Read existing service files to avoid duplication or contradiction.
+4. Implement the minimum code that satisfies the spec.
+5. Write unit tests in `tests/unit/services/` using in-memory fakes, not mocks.
+6. Run `pytest tests/unit/services/` to verify.
+
+## Rules
+
+- Services import from `domain/` only — never from `infra/` or `ui/` directly.
+- Services depend on ports (ABCs), not concrete implementations. Concrete classes are injected at startup.
+- No business logic belongs in infra or UI — if it's a rule, it lives here or in domain.
+- Worker threads must not block the Flet event loop. Use `threading.Thread(daemon=True)` for background work.
+- Rate limit detection is a service concern: detect → pause task → reschedule.
+- If the spec is ambiguous, stop and ask. Do not interpret liberally.
+- Never modify files outside your zone without explicit instruction.
+
+## Dependency injection pattern
+
+Services receive port implementations via constructor injection:
+
+```python
+class TaskQueueService:
+    def __init__(self, repo: TaskRepository, runner: SubprocessRunner) -> None:
+        self._repo = repo
+        self._runner = runner
+```
+
+Never instantiate concrete infra classes inside a service.
+
+## Test pattern for services
+
+Use in-memory fakes that implement the port ABCs:
+
+```python
+class FakeTaskRepository(TaskRepository):
+    def __init__(self) -> None:
+        self._tasks: dict[str, Task] = {}
+
+    def save(self, task: Task) -> None:
+        self._tasks[task.id] = task
+
+    def get(self, task_id: str) -> Task | None:
+        return self._tasks.get(task_id)
+```
+
+Prefer fakes over `unittest.mock.Mock` — they catch interface drift and align with BDD step patterns.
+
+## Code style
+
+- Python 3.11+, type hints everywhere.
+- snake_case for functions/modules, PascalCase for classes.
+- No docstrings unless the logic is non-obvious.
+- Conventional commits: `feat(services):`, `fix(services):`, `refactor(services):`

--- a/.claude/agents/spec-writer.md
+++ b/.claude/agents/spec-writer.md
@@ -1,0 +1,51 @@
+---
+name: spec-writer
+description: Writes and updates specs in specs/contracts/, specs/schemas/, and specs/rules/. Use when defining new features, ports, schemas, or business rules before implementation.
+tools: Read, Write, Edit, Glob, Grep
+model: sonnet
+color: blue
+---
+
+You are a spec writer for AIHelm, a desktop app that queues and supervises AI CLI tasks.
+
+Your sole responsibility is the `specs/` directory. You never touch source code or tests.
+
+## What you produce
+
+- `specs/contracts/` — interface/port definitions in Markdown. Describe method signatures, parameters, return types, and error conditions.
+- `specs/schemas/` — JSON schemas for domain data (Task, StatusEnum, etc.).
+- `specs/rules/` — business invariants and state machine rules in Markdown.
+
+## Workflow
+
+1. Read existing specs first to avoid duplication or contradiction.
+2. Write the spec document with clear sections: Purpose, Interface, Constraints, Examples.
+3. For schemas, use JSON Schema draft-07 format.
+4. For rules, use numbered invariants and state transition tables.
+
+## Constraints
+
+- Do NOT write or modify any file outside `specs/`.
+- Do NOT implement anything — specs describe intent, not code.
+- If a rule contradicts an existing spec, flag the conflict explicitly and ask for resolution before writing.
+- Use plain Markdown. No mermaid diagrams unless explicitly requested.
+
+## Format for contracts
+
+```markdown
+# <ComponentName> Contract
+
+## Purpose
+One paragraph.
+
+## Interface
+
+### method_name(param: Type) -> ReturnType
+Description, preconditions, postconditions, exceptions.
+
+## Constraints
+Numbered list of invariants.
+
+## Open Questions
+Anything unresolved.
+```

--- a/.claude/agents/unit-test-writer.md
+++ b/.claude/agents/unit-test-writer.md
@@ -1,0 +1,385 @@
+---
+name: "unit-test-writer"
+description: "Use this agent when new code has been written in `src/aihelm/` and you need unit tests that complement (not duplicate) the BDD test suite. This agent should be invoked after implementing domain models, ports, services, or infra components to fill coverage gaps left by the `bdd-writer` agent, targeting 80–90% global coverage.\\n\\n<example>\\nContext: A developer has just implemented a new `validate_task()` function in the domain layer and the bdd-writer has already generated feature/step files covering the happy path.\\nuser: \"I just finished implementing validate_task() in the domain models. Can you make sure it's well tested?\"\\nassistant: \"I'll use the unit-test-writer agent to analyze what BDD already covers and write complementary unit tests for the internal logic and edge cases.\"\\n<commentary>\\nThe bdd-writer already handles high-level behavior. The unit-test-writer should now cover edge cases like None inputs, invalid values, and internal branch logic not visible from BDD scenarios.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: The infra layer has a new JsonTaskRepository implementation. BDD steps cover the main CRUD flows.\\nuser: \"JsonTaskRepository is done. What's missing for testing?\"\\nassistant: \"Let me launch the unit-test-writer agent to detect coverage gaps and write unit tests for error handling, edge cases, and internal transformations not covered by BDD.\"\\n<commentary>\\nBDD covers end-to-end persistence flows. Unit tests should cover corrupt JSON handling, concurrent write conflicts, empty file scenarios, and schema validation edge cases.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: A developer adds a complex rate limit detection algorithm in RateLimitService.\\nuser: \"The rate limit detection logic is implemented. The BDD agent already wrote scenarios for the main patterns.\"\\nassistant: \"I'll invoke the unit-test-writer agent to cover the internal branches, boundary conditions, and regex edge cases in RateLimitDetector that BDD scenarios don't reach.\"\\n<commentary>\\nBDD covers observable behavior (task paused on rate limit). Unit tests should cover internal pattern matching, timing logic, and all detection branches.\\n</commentary>\\n</example>"
+tools: Bash, CronCreate, CronDelete, CronList, Edit, EnterWorktree, ExitWorktree, Glob, Grep, LSP, NotebookEdit, Read, RemoteTrigger, Skill, TaskCreate, TaskGet, TaskList, TaskUpdate, ToolSearch, Write
+model: sonnet
+color: red
+memory: project
+---
+
+You are a specialized unit test engineer working on the AIHelm project — a Python/Flet desktop application that orchestrates AI CLI tools (claude-code). You operate as a complement to the `bdd-writer` agent, which already covers high-level behavior via Gherkin `.feature` files and `pytest-bdd` step implementations.
+
+Your mission is to close coverage gaps that BDD cannot reach, targeting **80–90% global coverage** through high-value unit tests — not artificial padding.
+
+---
+
+## Project Context
+
+**Architecture**: Clean Architecture with 4 layers — Domain → Services → Infra → UI. Dependencies flow inward.
+
+**Test layout**:
+```
+tests/
+  unit/domain/       # Pure logic, no mocks needed
+  unit/services/     # Mocked/faked ports
+  unit/infra/        # Concrete infra tests
+  integration/       # E2E with real filesystem and git
+  bdd/features/      # Gherkin .feature files (owned by bdd-writer)
+  bdd/steps/         # pytest-bdd steps (owned by bdd-writer)
+```
+
+**Source code**: `src/aihelm/` with `domain/`, `services/`, `infra/`, `ui/`
+
+**Test runner**: `pytest` with `pytest-bdd`
+
+**Quality gates**: Ruff (lint), Mypy (types), Bandit (security) — all tests must pass these.
+
+---
+
+## Critical Rule: Never Duplicate BDD
+
+Before writing any test, you MUST:
+
+1. Read all existing BDD files:
+   - `tests/bdd/features/*.feature`
+   - `tests/bdd/steps/*.py`
+
+2. Ask yourself for each potential test:
+   - Is this behavior already validated at the BDD level?
+   - ✅ Yes → **Do NOT write an equivalent unit test**
+   - ❌ No → Write the unit test
+
+**BDD covers**: complete flows, main business rules, user-observable behavior.
+
+**You cover**: internal logic, edge cases, error branches, data transformations, conditions invisible from outside.
+
+---
+
+## Your Responsibilities
+
+### Phase 1: Gap Analysis
+
+Before writing a single test, produce a structured gap analysis:
+
+```text
+Current estimated coverage: ~XX%
+
+BDD covers:
+- [list of scenarios/behaviors already covered]
+
+Gaps identified:
+- [module]: [specific uncovered branch/case]
+- [module]: [edge case]
+- [module]: [error handling path]
+```
+
+Focus gap analysis on:
+- Conditional branches not exercised by BDD
+- Internal validation logic
+- Data transformation functions
+- Error handling and exception paths
+- Boundary values and limits
+
+### Phase 2: Test Design
+
+For each gap, design tests covering:
+
+**Edge cases**:
+- `None` / missing values
+- Empty collections
+- Extreme numeric values
+- Invalid types or formats
+- Boundary conditions (e.g., exactly at a limit vs. one over)
+
+**Internal logic**:
+- Complex conditionals with multiple branches
+- State machine transitions (especially `StatusEnum` in domain/models)
+- Data parsing and serialization
+- Error propagation chains
+
+**Error handling**:
+- Expected exceptions with correct messages
+- Graceful degradation paths
+- Recovery logic
+
+### Phase 3: Implementation
+
+**File naming**: `test_<module_name>.py` in the correct `tests/unit/` subdirectory:
+- Domain logic → `tests/unit/domain/`
+- Service logic → `tests/unit/services/`
+- Infra implementations → `tests/unit/infra/`
+
+**Test naming**: Use descriptive names that explain intent:
+```python
+def test_should_raise_value_error_when_task_title_is_empty():
+def test_should_return_none_when_pattern_not_found():
+def test_should_transition_to_failed_when_subprocess_exits_nonzero():
+```
+
+**AAA structure** — every test must follow:
+```python
+def test_should_..._when_...():
+    # Arrange
+    ...
+
+    # Act
+    ...
+
+    # Assert
+    ...
+```
+
+**Isolation rules**:
+- Domain tests: NO mocks needed — pure functions and value objects
+- Service tests: Mock/fake ports (ABCs in `domain/ports/`) using in-memory fakes
+- Infra tests: Use real filesystem (temp dirs), real subprocess where safe
+- NEVER mock business logic — only mock I/O boundaries (DB, filesystem, subprocess, APIs)
+- Prefer in-memory fakes over `unittest.mock.Mock` for ports — aligns with the BDD agent pattern
+
+**Code standards** (from CLAUDE.md):
+- snake_case for functions and modules
+- PascalCase for classes
+- Never import from `infra/` or `ui/` in domain or services — only through ports
+- Type hints required (Mypy will check)
+- No secrets or large files
+
+### Phase 4: Quality Validation
+
+Before finalizing, verify each test:
+- [ ] Independent (does not depend on other tests or test order)
+- [ ] Deterministic (same result every run)
+- [ ] Tests exactly ONE behavior
+- [ ] Clear failure message when it fails
+- [ ] No overlap with existing BDD scenarios
+- [ ] Passes Ruff linting rules
+- [ ] Passes Mypy type checking
+- [ ] No `assert` without a message when testing exceptions
+
+### Phase 5: Coverage Report
+
+After implementation, provide:
+
+```text
+Estimated global coverage: XX%
+
+Distribution:
+- BDD contribution: ~55-60%
+- Unit test contribution (new): ~25-30%
+
+Coverage by module:
+- domain/models/: XX%
+- domain/ports/: XX% (mostly ABCs, expected low)
+- services/: XX%
+- infra/: XX%
+
+Artificial coverage detected: NONE / [list if found]
+
+Remaining gaps (acceptable):
+- [module]: [reason it's acceptable, e.g., "pure delegation", "UI event wiring"]
+```
+
+---
+
+## Anti-Patterns — Never Do These
+
+- ❌ Duplicate a BDD scenario as a unit test
+- ❌ Test through multiple layers (that's integration/BDD territory)
+- ❌ Mock domain/business logic itself
+- ❌ Write tests that only pass with specific implementation details (fragile)
+- ❌ Write tests to inflate coverage numbers with trivial assertions
+- ❌ Test UI components with unit tests
+- ❌ Import from `infra/` or `ui/` in domain/service tests
+
+---
+
+## Collaboration with bdd-writer
+
+**You do NOT own**:
+- `.feature` files
+- `tests/bdd/steps/` files
+- Integration/E2E flows
+- User-visible behavior scenarios
+
+**You DO own**:
+- `tests/unit/domain/`
+- `tests/unit/services/`
+- `tests/unit/infra/`
+- Internal precision that makes BDD scenarios trustworthy
+
+---
+
+## Output Format
+
+Always structure your output as:
+
+### 1. Gap Analysis
+What is not covered and why it matters.
+
+### 2. Coverage Strategy
+Which gaps you will address, which you will skip and why.
+
+### 3. Implemented Tests
+Full, runnable Python code ready to commit.
+
+### 4. Coverage Estimate
+Before/after breakdown.
+
+### 5. Observations
+- Design problems found (untestable code, tight coupling)
+- Suggested refactors (do NOT refactor unless asked)
+- Patterns that the bdd-writer should know about
+
+---
+
+## Philosophy
+
+BDD ensures the system **does the right thing**. You ensure it **does it correctly internally**.
+
+- BDD = observable behavior correctness
+- Unit tests = internal precision and robustness
+- 80–90% coverage = ~55% BDD + ~30% high-value unit tests
+- Every test you write must earn its existence by catching a real bug class
+
+**Update your agent memory** as you discover patterns, common gaps, testability issues, and architectural decisions in this codebase. This builds institutional knowledge across conversations.
+
+Examples of what to record:
+- Modules with recurring edge case patterns (e.g., `StatusEnum` transition gaps)
+- Ports that are consistently undertested
+- Common BDD coverage boundaries (what bdd-writer typically covers vs. leaves open)
+- In-memory fake implementations that can be reused across test files
+- Modules with design issues that make testing difficult (candidates for refactor)
+
+# Persistent Agent Memory
+
+You have a persistent, file-based memory system at `/Users/dgarcia/Documents/aihelm/.claude/agent-memory/unit-test-writer/`. This directory already exists — write to it directly with the Write tool (do not run mkdir or check for its existence).
+
+You should build up this memory system over time so that future conversations can have a complete picture of who the user is, how they'd like to collaborate with you, what behaviors to avoid or repeat, and the context behind the work the user gives you.
+
+If the user explicitly asks you to remember something, save it immediately as whichever type fits best. If they ask you to forget something, find and remove the relevant entry.
+
+## Types of memory
+
+There are several discrete types of memory that you can store in your memory system:
+
+<types>
+<type>
+    <name>user</name>
+    <description>Contain information about the user's role, goals, responsibilities, and knowledge. Great user memories help you tailor your future behavior to the user's preferences and perspective. Your goal in reading and writing these memories is to build up an understanding of who the user is and how you can be most helpful to them specifically. For example, you should collaborate with a senior software engineer differently than a student who is coding for the very first time. Keep in mind, that the aim here is to be helpful to the user. Avoid writing memories about the user that could be viewed as a negative judgement or that are not relevant to the work you're trying to accomplish together.</description>
+    <when_to_save>When you learn any details about the user's role, preferences, responsibilities, or knowledge</when_to_save>
+    <how_to_use>When your work should be informed by the user's profile or perspective. For example, if the user is asking you to explain a part of the code, you should answer that question in a way that is tailored to the specific details that they will find most valuable or that helps them build their mental model in relation to domain knowledge they already have.</how_to_use>
+    <examples>
+    user: I'm a data scientist investigating what logging we have in place
+    assistant: [saves user memory: user is a data scientist, currently focused on observability/logging]
+
+    user: I've been writing Go for ten years but this is my first time touching the React side of this repo
+    assistant: [saves user memory: deep Go expertise, new to React and this project's frontend — frame frontend explanations in terms of backend analogues]
+    </examples>
+</type>
+<type>
+    <name>feedback</name>
+    <description>Guidance the user has given you about how to approach work — both what to avoid and what to keep doing. These are a very important type of memory to read and write as they allow you to remain coherent and responsive to the way you should approach work in the project. Record from failure AND success: if you only save corrections, you will avoid past mistakes but drift away from approaches the user has already validated, and may grow overly cautious.</description>
+    <when_to_save>Any time the user corrects your approach ("no not that", "don't", "stop doing X") OR confirms a non-obvious approach worked ("yes exactly", "perfect, keep doing that", accepting an unusual choice without pushback). Corrections are easy to notice; confirmations are quieter — watch for them. In both cases, save what is applicable to future conversations, especially if surprising or not obvious from the code. Include *why* so you can judge edge cases later.</when_to_save>
+    <how_to_use>Let these memories guide your behavior so that the user does not need to offer the same guidance twice.</how_to_use>
+    <body_structure>Lead with the rule itself, then a **Why:** line (the reason the user gave — often a past incident or strong preference) and a **How to apply:** line (when/where this guidance kicks in). Knowing *why* lets you judge edge cases instead of blindly following the rule.</body_structure>
+    <examples>
+    user: don't mock the database in these tests — we got burned last quarter when mocked tests passed but the prod migration failed
+    assistant: [saves feedback memory: integration tests must hit a real database, not mocks. Reason: prior incident where mock/prod divergence masked a broken migration]
+
+    user: stop summarizing what you just did at the end of every response, I can read the diff
+    assistant: [saves feedback memory: this user wants terse responses with no trailing summaries]
+
+    user: yeah the single bundled PR was the right call here, splitting this one would've just been churn
+    assistant: [saves feedback memory: for refactors in this area, user prefers one bundled PR over many small ones. Confirmed after I chose this approach — a validated judgment call, not a correction]
+    </examples>
+</type>
+<type>
+    <name>project</name>
+    <description>Information that you learn about ongoing work, goals, initiatives, bugs, or incidents within the project that is not otherwise derivable from the code or git history. Project memories help you understand the broader context and motivation behind the work the user is doing within this working directory.</description>
+    <when_to_save>When you learn who is doing what, why, or by when. These states change relatively quickly so try to keep your understanding of this up to date. Always convert relative dates in user messages to absolute dates when saving (e.g., "Thursday" → "2026-03-05"), so the memory remains interpretable after time passes.</when_to_save>
+    <how_to_use>Use these memories to more fully understand the details and nuance behind the user's request and make better informed suggestions.</how_to_use>
+    <body_structure>Lead with the fact or decision, then a **Why:** line (the motivation — often a constraint, deadline, or stakeholder ask) and a **How to apply:** line (how this should shape your suggestions). Project memories decay fast, so the why helps future-you judge whether the memory is still load-bearing.</body_structure>
+    <examples>
+    user: we're freezing all non-critical merges after Thursday — mobile team is cutting a release branch
+    assistant: [saves project memory: merge freeze begins 2026-03-05 for mobile release cut. Flag any non-critical PR work scheduled after that date]
+
+    user: the reason we're ripping out the old auth middleware is that legal flagged it for storing session tokens in a way that doesn't meet the new compliance requirements
+    assistant: [saves project memory: auth middleware rewrite is driven by legal/compliance requirements around session token storage, not tech-debt cleanup — scope decisions should favor compliance over ergonomics]
+    </examples>
+</type>
+<type>
+    <name>reference</name>
+    <description>Stores pointers to where information can be found in external systems. These memories allow you to remember where to look to find up-to-date information outside of the project directory.</description>
+    <when_to_save>When you learn about resources in external systems and their purpose. For example, that bugs are tracked in a specific project in Linear or that feedback can be found in a specific Slack channel.</when_to_save>
+    <how_to_use>When the user references an external system or information that may be in an external system.</how_to_use>
+    <examples>
+    user: check the Linear project "INGEST" if you want context on these tickets, that's where we track all pipeline bugs
+    assistant: [saves reference memory: pipeline bugs are tracked in Linear project "INGEST"]
+
+    user: the Grafana board at grafana.internal/d/api-latency is what oncall watches — if you're touching request handling, that's the thing that'll page someone
+    assistant: [saves reference memory: grafana.internal/d/api-latency is the oncall latency dashboard — check it when editing request-path code]
+    </examples>
+</type>
+</types>
+
+## What NOT to save in memory
+
+- Code patterns, conventions, architecture, file paths, or project structure — these can be derived by reading the current project state.
+- Git history, recent changes, or who-changed-what — `git log` / `git blame` are authoritative.
+- Debugging solutions or fix recipes — the fix is in the code; the commit message has the context.
+- Anything already documented in CLAUDE.md files.
+- Ephemeral task details: in-progress work, temporary state, current conversation context.
+
+These exclusions apply even when the user explicitly asks you to save. If they ask you to save a PR list or activity summary, ask what was *surprising* or *non-obvious* about it — that is the part worth keeping.
+
+## How to save memories
+
+Saving a memory is a two-step process:
+
+**Step 1** — write the memory to its own file (e.g., `user_role.md`, `feedback_testing.md`) using this frontmatter format:
+
+```markdown
+---
+name: {{memory name}}
+description: {{one-line description — used to decide relevance in future conversations, so be specific}}
+type: {{user, feedback, project, reference}}
+---
+
+{{memory content — for feedback/project types, structure as: rule/fact, then **Why:** and **How to apply:** lines}}
+```
+
+**Step 2** — add a pointer to that file in `MEMORY.md`. `MEMORY.md` is an index, not a memory — each entry should be one line, under ~150 characters: `- [Title](file.md) — one-line hook`. It has no frontmatter. Never write memory content directly into `MEMORY.md`.
+
+- `MEMORY.md` is always loaded into your conversation context — lines after 200 will be truncated, so keep the index concise
+- Keep the name, description, and type fields in memory files up-to-date with the content
+- Organize memory semantically by topic, not chronologically
+- Update or remove memories that turn out to be wrong or outdated
+- Do not write duplicate memories. First check if there is an existing memory you can update before writing a new one.
+
+## When to access memories
+- When memories seem relevant, or the user references prior-conversation work.
+- You MUST access memory when the user explicitly asks you to check, recall, or remember.
+- If the user says to *ignore* or *not use* memory: proceed as if MEMORY.md were empty. Do not apply remembered facts, cite, compare against, or mention memory content.
+- Memory records can become stale over time. Use memory as context for what was true at a given point in time. Before answering the user or building assumptions based solely on information in memory records, verify that the memory is still correct and up-to-date by reading the current state of the files or resources. If a recalled memory conflicts with current information, trust what you observe now — and update or remove the stale memory rather than acting on it.
+
+## Before recommending from memory
+
+A memory that names a specific function, file, or flag is a claim that it existed *when the memory was written*. It may have been renamed, removed, or never merged. Before recommending it:
+
+- If the memory names a file path: check the file exists.
+- If the memory names a function or flag: grep for it.
+- If the user is about to act on your recommendation (not just asking about history), verify first.
+
+"The memory says X exists" is not the same as "X exists now."
+
+A memory that summarizes repo state (activity logs, architecture snapshots) is frozen in time. If the user asks about *recent* or *current* state, prefer `git log` or reading the code over recalling the snapshot.
+
+## Memory and other forms of persistence
+Memory is one of several persistence mechanisms available to you as you assist the user in a given conversation. The distinction is often that memory can be recalled in future conversations and should not be used for persisting information that is only useful within the scope of the current conversation.
+- When to use or update a plan instead of memory: If you are about to start a non-trivial implementation task and would like to reach alignment with the user on your approach you should use a Plan rather than saving this information to memory. Similarly, if you already have a plan within the conversation and you have changed your approach persist that change by updating the plan rather than saving a memory.
+- When to use or update tasks instead of memory: When you need to break your work in current conversation into discrete steps or keep track of your progress use tasks instead of saving to memory. Tasks are great for persisting information about the work that needs to be done in the current conversation, but memory should be reserved for information that will be useful in future conversations.
+
+- Since this memory is project-scope and shared with your team via version control, tailor your memories to this project
+
+## MEMORY.md
+
+Your MEMORY.md is currently empty. When you save new memories, they will appear here.

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(xargs ls:*)",
+      "Bash(git:*)"
+    ]
+  }
+}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 
 ## Changes
 
-- 
+-
 
 ## Specs Updated
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = ["."]
 addopts = "--strict-markers -v"
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
@@ -89,6 +90,10 @@ markers = [
 [tool.coverage.run]
 source = ["src/aihelm"]
 branch = true
+omit = [
+    "src/aihelm/__main__.py",
+    "src/aihelm/ui/*",
+]
 
 [tool.coverage.report]
 fail_under = 80

--- a/specs/contracts/task_repository.md
+++ b/specs/contracts/task_repository.md
@@ -1,0 +1,38 @@
+# TaskRepository Contract
+
+Port interface for persisting and retrieving tasks.
+
+## Operations
+
+### save(task: Task) -> None
+
+Persist a task. If a task with the same `id` already exists, it is replaced (upsert).
+
+**Postcondition:** `get(task.id)` returns a task equal to the one saved.
+
+### get(task_id: str) -> Task | None
+
+Retrieve a task by its unique ID. Returns `None` if no task with that ID exists.
+
+### list_by_status(status: StatusEnum) -> list[Task]
+
+Return all tasks matching the given status, ordered by `position` ascending.
+
+### list_all() -> list[Task]
+
+Return all tasks regardless of status, ordered by `position` ascending.
+
+### delete(task_id: str) -> None
+
+Remove the task with the given ID. No-op if the task does not exist.
+
+### next_position() -> int
+
+Return the next available position number: `max(position) + 1` across all tasks, or `0` if the repository is empty.
+
+## Constraints
+
+- **Atomic writes:** A failed write must not corrupt existing data.
+- **Thread safety:** Concurrent reads must not raise errors. Writes are serialized.
+- **Configurable path:** The storage location (file path) is provided at construction time.
+- **Missing storage:** If the backing store does not exist on read, return empty results (do not raise).

--- a/specs/rules/task_queue_rules.md
+++ b/specs/rules/task_queue_rules.md
@@ -27,6 +27,14 @@ Business invariants governing task creation and queue management.
 8. **Ordering:** Tasks in the queue are displayed and processed in `position` ascending order.
 9. **Branch uniqueness:** No two active tasks (status `queued` or `running`) may share the same `branch_name`. A branch name may be reused once the previous task using it has reached a terminal status (`done` or `failed`).
 
+## Edit Rules
+
+12. **Editable fields:** Only `name`, `prompt`, and `branch_name` may be edited. The fields `id`, `status`, `created_at`, and `position` are immutable after creation.
+13. **Edit precondition:** A task may only be edited when its status is `queued`. Attempting to edit a task in any other status must be rejected.
+14. **Validation on edit:** All creation-time validation rules (rules 2-4) apply equally to edited values. An edit that would produce an invalid task must be rejected, leaving the original task unchanged.
+15. **Branch uniqueness on edit:** Rule 9 (branch uniqueness among active tasks) applies to edits. The task being edited is excluded from the conflict check (a task may keep its own branch name).
+16. **Atomic edit:** An edit either succeeds entirely (all changed fields persisted) or fails entirely (no fields changed).
+
 ## Persistence Rules
 
 10. **Startup load:** On application startup, the queue is populated from the persisted storage.

--- a/specs/rules/task_queue_rules.md
+++ b/specs/rules/task_queue_rules.md
@@ -35,6 +35,12 @@ Business invariants governing task creation and queue management.
 15. **Branch uniqueness on edit:** Rule 9 (branch uniqueness among active tasks) applies to edits. The task being edited is excluded from the conflict check (a task may keep its own branch name).
 16. **Atomic edit:** An edit either succeeds entirely (all changed fields persisted) or fails entirely (no fields changed).
 
+## Delete Rules
+
+17. **Delete precondition:** A task may be deleted when its status is `queued`, `paused`, `done`, or `failed`. A `running` task cannot be deleted.
+18. **Delete is irreversible:** Once deleted, the task and its data are permanently removed from persistence.
+19. **Branch release on delete:** Deleting an active task (`queued`) releases its branch name for reuse.
+
 ## Persistence Rules
 
 10. **Startup load:** On application startup, the queue is populated from the persisted storage.

--- a/specs/rules/task_queue_rules.md
+++ b/specs/rules/task_queue_rules.md
@@ -1,0 +1,33 @@
+# Task Queue Rules
+
+Business invariants governing task creation and queue management.
+
+## Creation Rules
+
+1. **Default status:** Every new task starts with status `queued`.
+2. **Branch validation:** The `branch_name` field must pass git-check-ref-format validation before the task is created. A branch name must NOT:
+   - Contain ASCII control characters (0x00-0x1F, 0x7F)
+   - Contain space, `~`, `^`, `:`, `?`, `*`, `[`, or `\`
+   - Contain `..` (double dot) anywhere
+   - Contain `@{` anywhere
+   - Start or end with `.`
+   - End with `.lock`
+   - Start with `-`
+   - End with `/`
+   - Contain consecutive slashes `//`
+   - Be exactly `@`
+3. **Name constraint:** Task name must be between 1 and 200 characters inclusive.
+4. **Prompt constraint:** Prompt must be non-empty.
+5. **Auto-generated ID:** Task ID is a UUID v4, assigned automatically at creation.
+6. **Auto-generated timestamp:** `created_at` is set to current UTC time at creation.
+7. **Auto-assigned position:** Position is set to `next_position()` from the repository.
+
+## Queue Rules
+
+8. **Ordering:** Tasks in the queue are displayed and processed in `position` ascending order.
+9. **Branch uniqueness:** No two active tasks (status `queued` or `running`) may share the same `branch_name`. A branch name may be reused once the previous task using it has reached a terminal status (`done` or `failed`).
+
+## Persistence Rules
+
+10. **Startup load:** On application startup, the queue is populated from the persisted storage.
+11. **Immediate persistence:** Every mutation (create, update, delete) is persisted immediately.

--- a/specs/schemas/task.json
+++ b/specs/schemas/task.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Task",
+  "description": "A unit of work to be executed by an AI code assistant.",
+  "type": "object",
+  "required": ["id", "name", "prompt", "branch_name", "status", "created_at", "position"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Unique identifier (UUID v4), auto-generated on creation."
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200,
+      "description": "Human-readable task name."
+    },
+    "prompt": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Instructions for the AI code assistant."
+    },
+    "branch_name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Target git branch name. Must conform to git-check-ref-format rules."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["queued", "running", "paused", "done", "failed"],
+      "default": "queued",
+      "description": "Current lifecycle state of the task."
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 UTC timestamp of task creation."
+    },
+    "position": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Queue ordering. Lower positions are executed first."
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/aihelm/__main__.py
+++ b/src/aihelm/__main__.py
@@ -26,6 +26,7 @@ def main(page: ft.Page) -> None:
     detail_view = TaskDetailView(
         queue_service=queue_service,
         on_task_updated=lambda _task: queue_view.refresh_list(),
+        on_task_deleted=lambda: queue_view.refresh_list(),
     )
 
     def _on_task_selected(task: Task) -> None:

--- a/src/aihelm/__main__.py
+++ b/src/aihelm/__main__.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import flet as ft
+
+from aihelm.infra.persistence import JsonTaskRepository
+from aihelm.services import TaskQueueService
+from aihelm.ui.views import QueueView
+
+_DEFAULT_DATA_DIR = Path.home() / ".aihelm"
+_TASKS_FILE = _DEFAULT_DATA_DIR / "tasks.json"
+
+
+def main(page: ft.Page) -> None:
+    page.title = "AIHelm"
+    page.window.width = 1200
+    page.window.height = 800
+    page.bgcolor = "#121212"
+    page.theme_mode = ft.ThemeMode.DARK
+
+    repo = JsonTaskRepository(path=_TASKS_FILE)
+    queue_service = TaskQueueService(repo=repo)
+    queue_view = QueueView(queue_service=queue_service)
+
+    page.add(
+        ft.Row(
+            controls=[
+                ft.Container(
+                    content=queue_view,
+                    width=380,
+                    bgcolor="#1a1a1a",
+                    border=ft.border.only(right=ft.BorderSide(1, "#333333")),
+                ),
+                ft.Container(
+                    content=ft.Column(
+                        controls=[
+                            ft.Text(
+                                "AIHelm",
+                                size=24,
+                                weight=ft.FontWeight.BOLD,
+                                color="#666666",
+                            ),
+                            ft.Text(
+                                "Select a task to begin execution.",
+                                color="#555555",
+                            ),
+                        ],
+                        alignment=ft.MainAxisAlignment.CENTER,
+                        horizontal_alignment=ft.CrossAxisAlignment.CENTER,
+                    ),
+                    expand=True,
+                    alignment=ft.Alignment(0, 0),
+                ),
+            ],
+            expand=True,
+        ),
+    )
+
+
+if __name__ == "__main__":
+    ft.app(target=main)  # type: ignore[no-untyped-call]

--- a/src/aihelm/__main__.py
+++ b/src/aihelm/__main__.py
@@ -4,9 +4,10 @@ from pathlib import Path
 
 import flet as ft
 
+from aihelm.domain.models.task import Task
 from aihelm.infra.persistence import JsonTaskRepository
 from aihelm.services import TaskQueueService
-from aihelm.ui.views import QueueView
+from aihelm.ui.views import QueueView, TaskDetailView
 
 _DEFAULT_DATA_DIR = Path.home() / ".aihelm"
 _TASKS_FILE = _DEFAULT_DATA_DIR / "tasks.json"
@@ -21,7 +22,19 @@ def main(page: ft.Page) -> None:
 
     repo = JsonTaskRepository(path=_TASKS_FILE)
     queue_service = TaskQueueService(repo=repo)
-    queue_view = QueueView(queue_service=queue_service)
+
+    detail_view = TaskDetailView(
+        queue_service=queue_service,
+        on_task_updated=lambda _task: queue_view.refresh_list(),
+    )
+
+    def _on_task_selected(task: Task) -> None:
+        detail_view.show_task(task)
+
+    queue_view = QueueView(
+        queue_service=queue_service,
+        on_task_selected=_on_task_selected,
+    )
 
     page.add(
         ft.Row(
@@ -33,24 +46,8 @@ def main(page: ft.Page) -> None:
                     border=ft.border.only(right=ft.BorderSide(1, "#333333")),
                 ),
                 ft.Container(
-                    content=ft.Column(
-                        controls=[
-                            ft.Text(
-                                "AIHelm",
-                                size=24,
-                                weight=ft.FontWeight.BOLD,
-                                color="#666666",
-                            ),
-                            ft.Text(
-                                "Select a task to begin execution.",
-                                color="#555555",
-                            ),
-                        ],
-                        alignment=ft.MainAxisAlignment.CENTER,
-                        horizontal_alignment=ft.CrossAxisAlignment.CENTER,
-                    ),
+                    content=detail_view,
                     expand=True,
-                    alignment=ft.Alignment(0, 0),
                 ),
             ],
             expand=True,

--- a/src/aihelm/domain/models/__init__.py
+++ b/src/aihelm/domain/models/__init__.py
@@ -1,0 +1,4 @@
+from aihelm.domain.models.status import StatusEnum
+from aihelm.domain.models.task import Task
+
+__all__ = ["StatusEnum", "Task"]

--- a/src/aihelm/domain/models/status.py
+++ b/src/aihelm/domain/models/status.py
@@ -1,0 +1,11 @@
+from enum import StrEnum
+
+
+class StatusEnum(StrEnum):
+    """Lifecycle states of a task."""
+
+    QUEUED = "queued"
+    RUNNING = "running"
+    PAUSED = "paused"
+    DONE = "done"
+    FAILED = "failed"

--- a/src/aihelm/domain/models/task.py
+++ b/src/aihelm/domain/models/task.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import re
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+from aihelm.domain.models.status import StatusEnum
+
+# Compiled regex for git-check-ref-format validation.
+# Rejects: control chars, space, ~^:?*[\, double-dot, @{, leading/trailing dot,
+# .lock suffix, leading dash, trailing slash, consecutive slashes, bare "@".
+_BRANCH_NAME_RE = re.compile(
+    r"^(?!\.)"  # no leading dot
+    r"(?!.*\.\.)"  # no double-dot anywhere
+    r"(?!.*@\{)"  # no @{ anywhere
+    r"(?!.*/\.)"  # no slash-dot (component starting with dot)
+    r"(?!.*//)"  # no consecutive slashes
+    r"(?!-)"  # no leading dash
+    r"[^\x00-\x1f\x7f ~^:?*\[\\]+"  # valid characters only
+    r"(?<!\.lock)"  # no .lock suffix
+    r"(?<!\.)"  # no trailing dot
+    r"(?<!/)$"  # no trailing slash
+)
+
+_BARE_AT = re.compile(r"^@$")
+
+
+@dataclass(frozen=True)
+class Task:
+    """A unit of work to be executed by an AI code assistant."""
+
+    name: str
+    prompt: str
+    branch_name: str
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    status: StatusEnum = StatusEnum.QUEUED
+    created_at: datetime = field(
+        default_factory=lambda: datetime.now(UTC),
+    )
+    position: int = 0
+
+    def __post_init__(self) -> None:
+        if not self.name or len(self.name) > 200:
+            msg = "Task name must be between 1 and 200 characters"
+            raise ValueError(msg)
+        if not self.prompt:
+            msg = "Prompt must not be empty"
+            raise ValueError(msg)
+        if _BARE_AT.match(self.branch_name) or not _BRANCH_NAME_RE.match(
+            self.branch_name,
+        ):
+            msg = f"Invalid git branch name: {self.branch_name!r}"
+            raise ValueError(msg)

--- a/src/aihelm/domain/ports/__init__.py
+++ b/src/aihelm/domain/ports/__init__.py
@@ -1,0 +1,3 @@
+from aihelm.domain.ports.task_repository import TaskRepository
+
+__all__ = ["TaskRepository"]

--- a/src/aihelm/domain/ports/task_repository.py
+++ b/src/aihelm/domain/ports/task_repository.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from aihelm.domain.models.status import StatusEnum
+from aihelm.domain.models.task import Task
+
+
+class TaskRepository(ABC):
+    """Port for persisting and retrieving tasks."""
+
+    @abstractmethod
+    def save(self, task: Task) -> None: ...
+
+    @abstractmethod
+    def get(self, task_id: str) -> Task | None: ...
+
+    @abstractmethod
+    def list_by_status(self, status: StatusEnum) -> list[Task]: ...
+
+    @abstractmethod
+    def list_all(self) -> list[Task]: ...
+
+    @abstractmethod
+    def delete(self, task_id: str) -> None: ...
+
+    @abstractmethod
+    def next_position(self) -> int: ...

--- a/src/aihelm/infra/persistence/__init__.py
+++ b/src/aihelm/infra/persistence/__init__.py
@@ -1,0 +1,3 @@
+from aihelm.infra.persistence.json_task_repository import JsonTaskRepository
+
+__all__ = ["JsonTaskRepository"]

--- a/src/aihelm/infra/persistence/json_task_repository.py
+++ b/src/aihelm/infra/persistence/json_task_repository.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+import threading
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from aihelm.domain.models.status import StatusEnum
+from aihelm.domain.models.task import Task
+from aihelm.domain.ports.task_repository import TaskRepository
+
+
+def _task_to_dict(task: Task) -> dict[str, Any]:
+    return {
+        "id": task.id,
+        "name": task.name,
+        "prompt": task.prompt,
+        "branch_name": task.branch_name,
+        "status": str(task.status),
+        "created_at": task.created_at.isoformat(),
+        "position": task.position,
+    }
+
+
+def _dict_to_task(data: dict[str, Any]) -> Task:
+    return Task(
+        id=data["id"],
+        name=data["name"],
+        prompt=data["prompt"],
+        branch_name=data["branch_name"],
+        status=StatusEnum(data["status"]),
+        created_at=datetime.fromisoformat(data["created_at"]).replace(
+            tzinfo=UTC,
+        ),
+        position=data["position"],
+    )
+
+
+class JsonTaskRepository(TaskRepository):
+    """TaskRepository backed by a JSON file with atomic writes."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._lock = threading.Lock()
+
+    def _read_all(self) -> list[dict[str, Any]]:
+        if not self._path.exists():
+            return []
+        raw = self._path.read_text(encoding="utf-8")
+        result: list[dict[str, Any]] = json.loads(raw)
+        return result
+
+    def _write_all(self, tasks: list[dict[str, Any]]) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self._path.with_suffix(".tmp")
+        tmp.write_text(
+            json.dumps(tasks, indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )
+        tmp.replace(self._path)
+
+    def save(self, task: Task) -> None:
+        with self._lock:
+            items = self._read_all()
+            for i, item in enumerate(items):
+                if item["id"] == task.id:
+                    items[i] = _task_to_dict(task)
+                    break
+            else:
+                items.append(_task_to_dict(task))
+            self._write_all(items)
+
+    def get(self, task_id: str) -> Task | None:
+        with self._lock:
+            for item in self._read_all():
+                if item["id"] == task_id:
+                    return _dict_to_task(item)
+        return None
+
+    def list_by_status(self, status: StatusEnum) -> list[Task]:
+        with self._lock:
+            items = self._read_all()
+        return sorted(
+            (_dict_to_task(i) for i in items if i["status"] == str(status)),
+            key=lambda t: t.position,
+        )
+
+    def list_all(self) -> list[Task]:
+        with self._lock:
+            items = self._read_all()
+        return sorted(
+            (_dict_to_task(i) for i in items),
+            key=lambda t: t.position,
+        )
+
+    def delete(self, task_id: str) -> None:
+        with self._lock:
+            items = [i for i in self._read_all() if i["id"] != task_id]
+            self._write_all(items)
+
+    def next_position(self) -> int:
+        with self._lock:
+            items = self._read_all()
+        if not items:
+            return 0
+        max_pos: int = max(i["position"] for i in items)
+        return max_pos + 1

--- a/src/aihelm/services/__init__.py
+++ b/src/aihelm/services/__init__.py
@@ -1,0 +1,3 @@
+from aihelm.services.task_queue_service import TaskQueueService
+
+__all__ = ["TaskQueueService"]

--- a/src/aihelm/services/task_queue_service.py
+++ b/src/aihelm/services/task_queue_service.py
@@ -74,6 +74,22 @@ class TaskQueueService:
         self._repo.save(updated)
         return updated
 
+    def delete_task(self, task_id: str) -> None:
+        """Delete a task from the queue.
+
+        Raises ValueError if the task is not found or is currently running.
+        """
+        existing = self._repo.get(task_id)
+        if existing is None:
+            msg = "Task not found"
+            raise ValueError(msg)
+
+        if existing.status == StatusEnum.RUNNING:
+            msg = "Cannot delete a running task"
+            raise ValueError(msg)
+
+        self._repo.delete(task_id)
+
     def list_queue(self) -> list[Task]:
         """Return all queued tasks ordered by position."""
         return self._repo.list_by_status(StatusEnum.QUEUED)

--- a/src/aihelm/services/task_queue_service.py
+++ b/src/aihelm/services/task_queue_service.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import dataclasses
+
 from aihelm.domain.models.status import StatusEnum
 from aihelm.domain.models.task import Task
 from aihelm.domain.ports.task_repository import TaskRepository
@@ -32,6 +34,45 @@ class TaskQueueService:
         )
         self._repo.save(task)
         return task
+
+    def update_task(
+        self,
+        task_id: str,
+        *,
+        name: str,
+        prompt: str,
+        branch_name: str,
+    ) -> Task:
+        """Edit a queued task's name, prompt, and branch_name.
+
+        Raises ValueError if the task is not found, is not queued,
+        the new branch conflicts with another active task, or any
+        field fails validation.
+        """
+        existing = self._repo.get(task_id)
+        if existing is None:
+            msg = "Task not found"
+            raise ValueError(msg)
+
+        if existing.status != StatusEnum.QUEUED:
+            msg = "Only queued tasks can be edited"
+            raise ValueError(msg)
+
+        if branch_name != existing.branch_name:
+            active = self._repo.list_by_status(StatusEnum.QUEUED)
+            active += self._repo.list_by_status(StatusEnum.RUNNING)
+            if any(t.branch_name == branch_name and t.id != task_id for t in active):
+                msg = f"Branch {branch_name!r} is already assigned to an active task"
+                raise ValueError(msg)
+
+        updated = dataclasses.replace(
+            existing,
+            name=name,
+            prompt=prompt,
+            branch_name=branch_name,
+        )
+        self._repo.save(updated)
+        return updated
 
     def list_queue(self) -> list[Task]:
         """Return all queued tasks ordered by position."""

--- a/src/aihelm/services/task_queue_service.py
+++ b/src/aihelm/services/task_queue_service.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from aihelm.domain.models.status import StatusEnum
+from aihelm.domain.models.task import Task
+from aihelm.domain.ports.task_repository import TaskRepository
+
+
+class TaskQueueService:
+    """Orchestrates task creation and queue listing."""
+
+    def __init__(self, repo: TaskRepository) -> None:
+        self._repo = repo
+
+    def add_task(self, name: str, prompt: str, branch_name: str) -> Task:
+        """Create a new task and add it to the queue.
+
+        Raises ValueError if branch_name is already used by an active task,
+        or if any field fails validation.
+        """
+        active = self._repo.list_by_status(StatusEnum.QUEUED)
+        active += self._repo.list_by_status(StatusEnum.RUNNING)
+        if any(t.branch_name == branch_name for t in active):
+            msg = f"Branch {branch_name!r} is already assigned to an active task"
+            raise ValueError(msg)
+
+        position = self._repo.next_position()
+        task = Task(
+            name=name,
+            prompt=prompt,
+            branch_name=branch_name,
+            position=position,
+        )
+        self._repo.save(task)
+        return task
+
+    def list_queue(self) -> list[Task]:
+        """Return all queued tasks ordered by position."""
+        return self._repo.list_by_status(StatusEnum.QUEUED)
+
+    def list_all_tasks(self) -> list[Task]:
+        """Return all tasks regardless of status, ordered by position."""
+        return self._repo.list_all()

--- a/src/aihelm/ui/components/__init__.py
+++ b/src/aihelm/ui/components/__init__.py
@@ -1,0 +1,4 @@
+from aihelm.ui.components.status_badge import StatusBadge
+from aihelm.ui.components.task_card import TaskCard
+
+__all__ = ["StatusBadge", "TaskCard"]

--- a/src/aihelm/ui/components/status_badge.py
+++ b/src/aihelm/ui/components/status_badge.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import flet as ft
+
+from aihelm.domain.models.status import StatusEnum
+
+_STATUS_COLORS: dict[StatusEnum, str] = {
+    StatusEnum.QUEUED: "#6c757d",
+    StatusEnum.RUNNING: "#0d6efd",
+    StatusEnum.PAUSED: "#ffc107",
+    StatusEnum.DONE: "#198754",
+    StatusEnum.FAILED: "#dc3545",
+}
+
+_STATUS_TEXT_COLORS: dict[StatusEnum, str] = {
+    StatusEnum.QUEUED: "#ffffff",
+    StatusEnum.RUNNING: "#ffffff",
+    StatusEnum.PAUSED: "#000000",
+    StatusEnum.DONE: "#ffffff",
+    StatusEnum.FAILED: "#ffffff",
+}
+
+
+class StatusBadge(ft.Container):
+    """Colored pill badge showing a task's status."""
+
+    def __init__(self, status: StatusEnum) -> None:
+        super().__init__(
+            content=ft.Text(
+                status.value.upper(),
+                size=11,
+                weight=ft.FontWeight.BOLD,
+                color=_STATUS_TEXT_COLORS.get(status, "#ffffff"),
+            ),
+            bgcolor=_STATUS_COLORS.get(status, "#6c757d"),
+            border_radius=12,
+            padding=ft.padding.symmetric(horizontal=8, vertical=2),
+        )

--- a/src/aihelm/ui/components/task_card.py
+++ b/src/aihelm/ui/components/task_card.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import flet as ft
+
+from aihelm.domain.models.task import Task
+from aihelm.ui.components.status_badge import StatusBadge
+
+
+class TaskCard(ft.Container):
+    """Card displaying a single task's summary."""
+
+    def __init__(self, task: Task) -> None:
+        super().__init__(
+            content=ft.Column(
+                controls=[
+                    ft.Row(
+                        controls=[
+                            ft.Text(
+                                task.name,
+                                weight=ft.FontWeight.W_600,
+                                size=14,
+                                expand=True,
+                                no_wrap=True,
+                                overflow=ft.TextOverflow.ELLIPSIS,
+                            ),
+                            StatusBadge(task.status),
+                        ],
+                        alignment=ft.MainAxisAlignment.SPACE_BETWEEN,
+                    ),
+                    ft.Text(
+                        task.branch_name,
+                        size=12,
+                        color="#888888",
+                        font_family="monospace",
+                        no_wrap=True,
+                        overflow=ft.TextOverflow.ELLIPSIS,
+                    ),
+                    ft.Text(
+                        task.created_at.strftime("%Y-%m-%d %H:%M"),
+                        size=11,
+                        color="#aaaaaa",
+                    ),
+                ],
+                spacing=4,
+            ),
+            padding=12,
+            border=ft.border.all(1, "#333333"),
+            border_radius=8,
+            bgcolor="#1e1e1e",
+        )

--- a/src/aihelm/ui/components/task_card.py
+++ b/src/aihelm/ui/components/task_card.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+
 import flet as ft
 
 from aihelm.domain.models.task import Task
@@ -9,7 +11,12 @@ from aihelm.ui.components.status_badge import StatusBadge
 class TaskCard(ft.Container):
     """Card displaying a single task's summary."""
 
-    def __init__(self, task: Task) -> None:
+    def __init__(
+        self,
+        task: Task,
+        on_click: Callable[[Task], None] | None = None,
+    ) -> None:
+        self.task = task
         super().__init__(
             content=ft.Column(
                 controls=[
@@ -47,4 +54,6 @@ class TaskCard(ft.Container):
             border=ft.border.all(1, "#333333"),
             border_radius=8,
             bgcolor="#1e1e1e",
+            ink=True,
+            on_click=lambda _e: on_click(task) if on_click else None,
         )

--- a/src/aihelm/ui/views/__init__.py
+++ b/src/aihelm/ui/views/__init__.py
@@ -1,0 +1,3 @@
+from aihelm.ui.views.queue_view import QueueView
+
+__all__ = ["QueueView"]

--- a/src/aihelm/ui/views/__init__.py
+++ b/src/aihelm/ui/views/__init__.py
@@ -1,3 +1,4 @@
 from aihelm.ui.views.queue_view import QueueView
+from aihelm.ui.views.task_detail_view import TaskDetailView
 
-__all__ = ["QueueView"]
+__all__ = ["QueueView", "TaskDetailView"]

--- a/src/aihelm/ui/views/queue_view.py
+++ b/src/aihelm/ui/views/queue_view.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+
 import flet as ft
 
+from aihelm.domain.models.task import Task
 from aihelm.services.task_queue_service import TaskQueueService
 from aihelm.ui.components.task_card import TaskCard
 
@@ -9,9 +12,14 @@ from aihelm.ui.components.task_card import TaskCard
 class QueueView(ft.Column):
     """Left sidebar containing the task creation form and queue list."""
 
-    def __init__(self, queue_service: TaskQueueService) -> None:
+    def __init__(
+        self,
+        queue_service: TaskQueueService,
+        on_task_selected: Callable[[Task], None] | None = None,
+    ) -> None:
         super().__init__()
         self._queue_service = queue_service
+        self._on_task_selected = on_task_selected
 
         self._name_field = ft.TextField(
             label="Task Name",
@@ -94,9 +102,15 @@ class QueueView(ft.Column):
     def did_mount(self) -> None:
         self._load_queue()
 
+    def refresh_list(self) -> None:
+        """Reload the task list from the service."""
+        self._load_queue()
+
     def _load_queue(self) -> None:
         tasks = self._queue_service.list_all_tasks()
-        self._task_list.controls = [TaskCard(t) for t in tasks]
+        self._task_list.controls = [
+            TaskCard(t, on_click=self._on_task_selected) for t in tasks
+        ]
         self._task_list.update()
 
     def _on_add_click(self, _e: ft.Event[ft.Button]) -> None:
@@ -115,7 +129,9 @@ class QueueView(ft.Column):
             self._error_text.update()
             return
 
-        self._task_list.controls.append(TaskCard(task))
+        self._task_list.controls.append(
+            TaskCard(task, on_click=self._on_task_selected),
+        )
         self._task_list.update()
 
         self._name_field.value = ""

--- a/src/aihelm/ui/views/queue_view.py
+++ b/src/aihelm/ui/views/queue_view.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import flet as ft
+
+from aihelm.services.task_queue_service import TaskQueueService
+from aihelm.ui.components.task_card import TaskCard
+
+
+class QueueView(ft.Column):
+    """Left sidebar containing the task creation form and queue list."""
+
+    def __init__(self, queue_service: TaskQueueService) -> None:
+        super().__init__()
+        self._queue_service = queue_service
+
+        self._name_field = ft.TextField(
+            label="Task Name",
+            hint_text="e.g. Refactor auth module",
+            dense=True,
+        )
+        self._prompt_field = ft.TextField(
+            label="Prompt",
+            hint_text="Instructions for the AI assistant...",
+            multiline=True,
+            min_lines=3,
+            max_lines=6,
+            dense=True,
+        )
+        self._branch_field = ft.TextField(
+            label="Branch Name",
+            hint_text="e.g. feature/refactor-auth",
+            dense=True,
+        )
+        self._add_button = ft.Button(
+            content=ft.Text("Add to Queue"),
+            icon=ft.Icons.ADD,
+            on_click=self._on_add_click,
+            style=ft.ButtonStyle(
+                bgcolor="#0d6efd",
+                color="#ffffff",
+            ),
+        )
+        self._error_text = ft.Text(
+            value="",
+            color="#dc3545",
+            size=12,
+            visible=False,
+        )
+        self._task_list = ft.ListView(
+            spacing=8,
+            expand=True,
+        )
+
+        self.spacing = 0
+        self.expand = True
+        self.controls = [
+            ft.Container(
+                content=ft.Column(
+                    controls=[
+                        ft.Text(
+                            "New Task",
+                            size=16,
+                            weight=ft.FontWeight.BOLD,
+                        ),
+                        self._name_field,
+                        self._prompt_field,
+                        self._branch_field,
+                        self._error_text,
+                        self._add_button,
+                    ],
+                    spacing=10,
+                ),
+                padding=16,
+            ),
+            ft.Divider(height=1),
+            ft.Container(
+                content=ft.Column(
+                    controls=[
+                        ft.Text(
+                            "Queue",
+                            size=16,
+                            weight=ft.FontWeight.BOLD,
+                        ),
+                        self._task_list,
+                    ],
+                    spacing=8,
+                    expand=True,
+                ),
+                padding=16,
+                expand=True,
+            ),
+        ]
+
+    def did_mount(self) -> None:
+        self._load_queue()
+
+    def _load_queue(self) -> None:
+        tasks = self._queue_service.list_all_tasks()
+        self._task_list.controls = [TaskCard(t) for t in tasks]
+        self._task_list.update()
+
+    def _on_add_click(self, _e: ft.Event[ft.Button]) -> None:
+        name = (self._name_field.value or "").strip()
+        prompt = (self._prompt_field.value or "").strip()
+        branch = (self._branch_field.value or "").strip()
+
+        self._error_text.visible = False
+        self._error_text.update()
+
+        try:
+            task = self._queue_service.add_task(name, prompt, branch)
+        except ValueError as exc:
+            self._error_text.value = str(exc)
+            self._error_text.visible = True
+            self._error_text.update()
+            return
+
+        self._task_list.controls.append(TaskCard(task))
+        self._task_list.update()
+
+        self._name_field.value = ""
+        self._prompt_field.value = ""
+        self._branch_field.value = ""
+        self._name_field.update()
+        self._prompt_field.update()
+        self._branch_field.update()

--- a/src/aihelm/ui/views/task_detail_view.py
+++ b/src/aihelm/ui/views/task_detail_view.py
@@ -17,10 +17,12 @@ class TaskDetailView(ft.Column):
         self,
         queue_service: TaskQueueService,
         on_task_updated: Callable[[Task], None] | None = None,
+        on_task_deleted: Callable[[], None] | None = None,
     ) -> None:
         super().__init__()
         self._queue_service = queue_service
         self._on_task_updated = on_task_updated
+        self._on_task_deleted = on_task_deleted
         self._current_task: Task | None = None
         self._editing = False
 
@@ -81,6 +83,18 @@ class TaskDetailView(ft.Column):
                     on_click=self._on_edit_click,
                     style=ft.ButtonStyle(
                         bgcolor="#0d6efd",
+                        color="#ffffff",
+                    ),
+                ),
+            )
+        if task.status != StatusEnum.RUNNING:
+            actions.append(
+                ft.Button(
+                    content=ft.Text("Delete"),
+                    icon=ft.Icons.DELETE,
+                    on_click=self._on_delete_click,
+                    style=ft.ButtonStyle(
+                        bgcolor="#dc3545",
                         color="#ffffff",
                     ),
                 ),
@@ -287,3 +301,57 @@ class TaskDetailView(ft.Column):
 
         if self._on_task_updated:
             self._on_task_updated(updated)
+
+    def _on_delete_click(self, _e: ft.Event[ft.Button]) -> None:
+        if self._current_task is None or self.page is None:
+            return
+
+        self._delete_dialog = ft.AlertDialog(
+            modal=True,
+            title=ft.Text("Delete Task"),
+            content=ft.Text(
+                f'Are you sure you want to delete "{self._current_task.name}"?'
+            ),
+            actions=[
+                ft.TextButton(
+                    "Cancel",
+                    on_click=self._close_delete_dialog,
+                ),
+                ft.TextButton(
+                    "Delete",
+                    on_click=self._confirm_delete,
+                    style=ft.ButtonStyle(color="#dc3545"),
+                ),
+            ],
+        )
+        self.page.overlay.append(self._delete_dialog)
+        self._delete_dialog.open = True
+        self.page.update()
+
+    def _close_delete_dialog(self, _e: ft.Event[ft.TextButton]) -> None:
+        if self.page is None:
+            return
+        self._delete_dialog.open = False
+        self.page.update()
+
+    def _confirm_delete(self, _e: ft.Event[ft.TextButton]) -> None:
+        if self._current_task is None or self.page is None:
+            return
+
+        self._delete_dialog.open = False
+        self.page.update()
+
+        try:
+            self._queue_service.delete_task(self._current_task.id)
+        except ValueError:
+            return
+
+        self._current_task = None
+        self._editing = False
+        self.alignment = ft.MainAxisAlignment.CENTER
+        self.horizontal_alignment = ft.CrossAxisAlignment.CENTER
+        self._show_empty_state()
+        self.update()
+
+        if self._on_task_deleted:
+            self._on_task_deleted()

--- a/src/aihelm/ui/views/task_detail_view.py
+++ b/src/aihelm/ui/views/task_detail_view.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import flet as ft
+
+from aihelm.domain.models.status import StatusEnum
+from aihelm.domain.models.task import Task
+from aihelm.services.task_queue_service import TaskQueueService
+from aihelm.ui.components.status_badge import StatusBadge
+
+
+class TaskDetailView(ft.Column):
+    """Right panel showing task details with edit capability."""
+
+    def __init__(
+        self,
+        queue_service: TaskQueueService,
+        on_task_updated: Callable[[Task], None] | None = None,
+    ) -> None:
+        super().__init__()
+        self._queue_service = queue_service
+        self._on_task_updated = on_task_updated
+        self._current_task: Task | None = None
+        self._editing = False
+
+        self.expand = True
+        self.alignment = ft.MainAxisAlignment.CENTER
+        self.horizontal_alignment = ft.CrossAxisAlignment.CENTER
+        self._show_empty_state()
+
+    def show_task(self, task: Task) -> None:
+        """Display a task in view mode."""
+        self._current_task = task
+        self._editing = False
+        self._build_view_mode()
+        self.update()
+
+    def _show_empty_state(self) -> None:
+        self.controls = [
+            ft.Text(
+                "AIHelm",
+                size=24,
+                weight=ft.FontWeight.BOLD,
+                color="#666666",
+            ),
+            ft.Text(
+                "Select a task to view details.",
+                color="#555555",
+            ),
+        ]
+
+    def _build_view_mode(self) -> None:
+        task = self._current_task
+        if task is None:
+            self._show_empty_state()
+            return
+
+        self.alignment = ft.MainAxisAlignment.START
+        self.horizontal_alignment = ft.CrossAxisAlignment.START
+
+        header_row = ft.Row(
+            controls=[
+                ft.Text(
+                    task.name,
+                    size=20,
+                    weight=ft.FontWeight.BOLD,
+                    expand=True,
+                ),
+                StatusBadge(task.status),
+            ],
+            alignment=ft.MainAxisAlignment.SPACE_BETWEEN,
+        )
+
+        actions: list[ft.Control] = []
+        if task.status == StatusEnum.QUEUED:
+            actions.append(
+                ft.Button(
+                    content=ft.Text("Edit"),
+                    icon=ft.Icons.EDIT,
+                    on_click=self._on_edit_click,
+                    style=ft.ButtonStyle(
+                        bgcolor="#0d6efd",
+                        color="#ffffff",
+                    ),
+                ),
+            )
+
+        self.controls = [
+            ft.Container(
+                content=ft.Column(
+                    controls=[
+                        header_row,
+                        ft.Divider(height=1),
+                        self._field_row("ID", task.id),
+                        self._field_row(
+                            "Created",
+                            task.created_at.strftime("%Y-%m-%d %H:%M:%S"),
+                        ),
+                        self._field_row("Branch", task.branch_name, monospace=True),
+                        ft.Divider(height=1),
+                        ft.Text(
+                            "Prompt",
+                            size=12,
+                            weight=ft.FontWeight.BOLD,
+                            color="#aaaaaa",
+                        ),
+                        ft.Container(
+                            content=ft.Text(
+                                task.prompt,
+                                size=14,
+                                color="#cccccc",
+                            ),
+                            bgcolor="#1e1e1e",
+                            border=ft.border.all(1, "#333333"),
+                            border_radius=8,
+                            padding=12,
+                        ),
+                        ft.Row(controls=actions) if actions else ft.Container(),
+                    ],
+                    spacing=12,
+                ),
+                padding=24,
+                expand=True,
+            ),
+        ]
+
+    def _build_edit_mode(self) -> None:
+        task = self._current_task
+        if task is None:
+            return
+
+        self.alignment = ft.MainAxisAlignment.START
+        self.horizontal_alignment = ft.CrossAxisAlignment.START
+
+        self._edit_name = ft.TextField(
+            label="Task Name",
+            value=task.name,
+            dense=True,
+        )
+        self._edit_prompt = ft.TextField(
+            label="Prompt",
+            value=task.prompt,
+            multiline=True,
+            min_lines=3,
+            max_lines=10,
+            dense=True,
+        )
+        self._edit_branch = ft.TextField(
+            label="Branch Name",
+            value=task.branch_name,
+            dense=True,
+        )
+        self._edit_error = ft.Text(
+            value="",
+            color="#dc3545",
+            size=12,
+            visible=False,
+        )
+
+        header_row = ft.Row(
+            controls=[
+                ft.Text(
+                    "Editing Task",
+                    size=20,
+                    weight=ft.FontWeight.BOLD,
+                    expand=True,
+                ),
+                StatusBadge(task.status),
+            ],
+            alignment=ft.MainAxisAlignment.SPACE_BETWEEN,
+        )
+
+        self.controls = [
+            ft.Container(
+                content=ft.Column(
+                    controls=[
+                        header_row,
+                        ft.Divider(height=1),
+                        self._field_row("ID", task.id),
+                        self._field_row(
+                            "Created",
+                            task.created_at.strftime("%Y-%m-%d %H:%M:%S"),
+                        ),
+                        ft.Divider(height=1),
+                        self._edit_name,
+                        self._edit_prompt,
+                        self._edit_branch,
+                        self._edit_error,
+                        ft.Row(
+                            controls=[
+                                ft.Button(
+                                    content=ft.Text("Save"),
+                                    icon=ft.Icons.SAVE,
+                                    on_click=self._on_save_click,
+                                    style=ft.ButtonStyle(
+                                        bgcolor="#198754",
+                                        color="#ffffff",
+                                    ),
+                                ),
+                                ft.Button(
+                                    content=ft.Text("Cancel"),
+                                    icon=ft.Icons.CANCEL,
+                                    on_click=self._on_cancel_click,
+                                    style=ft.ButtonStyle(
+                                        bgcolor="#6c757d",
+                                        color="#ffffff",
+                                    ),
+                                ),
+                            ],
+                            spacing=8,
+                        ),
+                    ],
+                    spacing=12,
+                ),
+                padding=24,
+                expand=True,
+            ),
+        ]
+
+    @staticmethod
+    def _field_row(
+        label: str,
+        value: str,
+        *,
+        monospace: bool = False,
+    ) -> ft.Row:
+        return ft.Row(
+            controls=[
+                ft.Text(
+                    label,
+                    size=12,
+                    weight=ft.FontWeight.BOLD,
+                    color="#aaaaaa",
+                    width=80,
+                ),
+                ft.Text(
+                    value,
+                    size=14,
+                    color="#cccccc",
+                    font_family="monospace" if monospace else None,
+                    expand=True,
+                    no_wrap=True,
+                    overflow=ft.TextOverflow.ELLIPSIS,
+                ),
+            ],
+        )
+
+    def _on_edit_click(self, _e: ft.Event[ft.Button]) -> None:
+        self._editing = True
+        self._build_edit_mode()
+        self.update()
+
+    def _on_cancel_click(self, _e: ft.Event[ft.Button]) -> None:
+        self._editing = False
+        self._build_view_mode()
+        self.update()
+
+    def _on_save_click(self, _e: ft.Event[ft.Button]) -> None:
+        if self._current_task is None:
+            return
+
+        name = (self._edit_name.value or "").strip()
+        prompt = (self._edit_prompt.value or "").strip()
+        branch = (self._edit_branch.value or "").strip()
+
+        self._edit_error.visible = False
+        self._edit_error.update()
+
+        try:
+            updated = self._queue_service.update_task(
+                self._current_task.id,
+                name=name,
+                prompt=prompt,
+                branch_name=branch,
+            )
+        except ValueError as exc:
+            self._edit_error.value = str(exc)
+            self._edit_error.visible = True
+            self._edit_error.update()
+            return
+
+        self._current_task = updated
+        self._editing = False
+        self._build_view_mode()
+        self.update()
+
+        if self._on_task_updated:
+            self._on_task_updated(updated)

--- a/tests/bdd/conftest.py
+++ b/tests/bdd/conftest.py
@@ -1,0 +1,1 @@
+"""BDD shared configuration."""

--- a/tests/bdd/features/task_delete.feature
+++ b/tests/bdd/features/task_delete.feature
@@ -1,0 +1,31 @@
+Feature: Task Deletion
+  As a developer
+  I want to delete tasks from the queue
+  So that I can remove tasks I no longer need
+
+  Background:
+    Given an empty task queue
+
+  Scenario: Delete a queued task
+    When I add a task with name "Unwanted" prompt "p" and branch "feature/unwanted"
+    And I delete the task
+    Then the queue contains 0 tasks
+
+  Scenario: Reject deleting a running task
+    Given a running task with name "Active" prompt "p" and branch "feature/active"
+    When I try to delete the task
+    Then I receive a validation error containing "Cannot delete a running task"
+
+  Scenario: Deleted task releases branch for reuse
+    When I add a task with name "First" prompt "p" and branch "feature/reuse"
+    And I delete the task
+    And I add a task with name "Second" prompt "p2" and branch "feature/reuse"
+    Then the queue contains 1 task
+    And the task has name "Second"
+
+  Scenario: Deletion persists across restarts
+    Given a JSON-backed task queue
+    When I add a task with name "Temp" prompt "p" and branch "feature/temp"
+    And I delete the task
+    And I reload the queue from storage
+    Then the queue contains 0 tasks

--- a/tests/bdd/features/task_edit.feature
+++ b/tests/bdd/features/task_edit.feature
@@ -1,0 +1,41 @@
+Feature: Task Editing
+  As a developer
+  I want to edit queued tasks
+  So that I can refine instructions before they are executed
+
+  Background:
+    Given an empty task queue
+
+  Scenario: Edit the name of a queued task
+    When I add a task with name "Original" prompt "do stuff" and branch "feature/orig"
+    And I edit the task name to "Updated"
+    Then the task has name "Updated"
+    And the task prompt is "do stuff"
+
+  Scenario: Edit the prompt of a queued task
+    When I add a task with name "T" prompt "Old prompt" and branch "feature/t"
+    And I edit the task prompt to "New prompt"
+    Then the task prompt is "New prompt"
+
+  Scenario: Edit the branch of a queued task
+    When I add a task with name "T" prompt "p" and branch "feature/old"
+    And I edit the task branch to "feature/new"
+    Then the task has branch "feature/new"
+
+  Scenario: Reject editing a running task
+    Given a running task with name "T" prompt "p" and branch "feature/run"
+    When I try to edit the task name to "New"
+    Then I receive a validation error containing "Only queued tasks can be edited"
+
+  Scenario: Reject duplicate branch on edit
+    When I add a task with name "A" prompt "p" and branch "feature/a"
+    And I add a task with name "B" prompt "p" and branch "feature/b"
+    And I try to edit task "B" branch to "feature/a"
+    Then I receive a validation error containing "already assigned"
+
+  Scenario: Edited task persists
+    Given a JSON-backed task queue
+    When I add a task with name "Before" prompt "p" and branch "feature/persist"
+    And I edit the task name to "After"
+    And I reload the queue from storage
+    Then the task has name "After"

--- a/tests/bdd/features/task_queue.feature
+++ b/tests/bdd/features/task_queue.feature
@@ -1,0 +1,38 @@
+Feature: Task Queue Management
+  As a developer
+  I want to add tasks with specific branch names to a waiting list
+  So that the AI can work sequentially without my constant intervention
+
+  Background:
+    Given an empty task queue
+
+  Scenario: Add a valid task to the queue
+    When I add a task with name "Fix login" prompt "Refactor auth module" and branch "feature/fix-login"
+    Then the queue contains 1 task
+    And the task has status "queued"
+    And the task has branch "feature/fix-login"
+
+  Scenario: Reject task with invalid branch name
+    When I try to add a task with name "Bad" prompt "p" and branch "feature/bad name"
+    Then I receive a validation error containing "Invalid git branch name"
+
+  Scenario: Reject task with empty name
+    When I try to add a task with an empty name
+    Then I receive a validation error containing "name"
+
+  Scenario: Reject duplicate active branch
+    Given a queued task with branch "feature/existing"
+    When I try to add a task with name "Dup" prompt "p" and branch "feature/existing"
+    Then I receive a validation error containing "already assigned"
+
+  Scenario: Tasks are ordered by position
+    When I add a task with name "First" prompt "p1" and branch "feature/first"
+    And I add a task with name "Second" prompt "p2" and branch "feature/second"
+    Then the queue lists "First" before "Second"
+
+  Scenario: Tasks persist across restarts
+    Given a JSON-backed task queue
+    When I add a task with name "Persistent" prompt "p" and branch "feature/persist"
+    And I reload the queue from storage
+    Then the queue contains 1 task
+    And the task has name "Persistent"

--- a/tests/bdd/steps/test_task_delete.py
+++ b/tests/bdd/steps/test_task_delete.py
@@ -1,0 +1,135 @@
+"""Step implementations for task_delete.feature."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pytest_bdd import given, parsers, scenario, then, when
+from tests.conftest import InMemoryTaskRepository
+
+from aihelm.domain.models.status import StatusEnum
+from aihelm.domain.models.task import Task
+from aihelm.infra.persistence.json_task_repository import JsonTaskRepository
+from aihelm.services.task_queue_service import TaskQueueService
+
+# --- Scenarios ---
+
+
+@scenario("../features/task_delete.feature", "Delete a queued task")
+def test_delete_queued_task() -> None:
+    pass
+
+
+@scenario("../features/task_delete.feature", "Reject deleting a running task")
+def test_reject_delete_running() -> None:
+    pass
+
+
+@scenario("../features/task_delete.feature", "Deleted task releases branch for reuse")
+def test_branch_reuse_after_delete() -> None:
+    pass
+
+
+@scenario("../features/task_delete.feature", "Deletion persists across restarts")
+def test_delete_persists() -> None:
+    pass
+
+
+# --- Fixtures ---
+
+
+@pytest.fixture()
+def context() -> dict[str, object]:
+    return {}
+
+
+# --- Given steps ---
+
+
+@given("an empty task queue", target_fixture="service")
+def empty_queue() -> TaskQueueService:
+    return TaskQueueService(repo=InMemoryTaskRepository())
+
+
+@given(
+    parsers.parse(
+        'a running task with name "{name}" prompt "{prompt}" and branch "{branch}"'
+    ),
+    target_fixture="last_task",
+)
+def running_task(
+    service: TaskQueueService, name: str, prompt: str, branch: str
+) -> Task:
+    task = Task(
+        name=name,
+        prompt=prompt,
+        branch_name=branch,
+        status=StatusEnum.RUNNING,
+        position=0,
+    )
+    service._repo.save(task)
+    return task
+
+
+@given("a JSON-backed task queue", target_fixture="service")
+def json_backed_queue(tmp_path: Path, context: dict[str, object]) -> TaskQueueService:
+    path = tmp_path / "tasks.json"
+    context["json_path"] = path
+    repo = JsonTaskRepository(path=path)
+    return TaskQueueService(repo=repo)
+
+
+# --- When steps ---
+
+
+@when(
+    parsers.parse(
+        'I add a task with name "{name}" prompt "{prompt}" and branch "{branch}"'
+    ),
+    target_fixture="last_task",
+)
+def add_task(service: TaskQueueService, name: str, prompt: str, branch: str) -> Task:
+    return service.add_task(name, prompt, branch)
+
+
+@when("I delete the task")
+def delete_task(service: TaskQueueService, last_task: Task) -> None:
+    service.delete_task(last_task.id)
+
+
+@when("I try to delete the task", target_fixture="error")
+def try_delete_task(service: TaskQueueService, last_task: Task) -> ValueError | None:
+    try:
+        service.delete_task(last_task.id)
+    except ValueError as exc:
+        return exc
+    return None
+
+
+@when("I reload the queue from storage", target_fixture="service")
+def reload_queue(context: dict[str, object]) -> TaskQueueService:
+    path: Path = context["json_path"]  # type: ignore[assignment]
+    repo = JsonTaskRepository(path=path)
+    return TaskQueueService(repo=repo)
+
+
+# --- Then steps ---
+
+
+@then(parsers.parse("the queue contains {count:d} task"))
+@then(parsers.parse("the queue contains {count:d} tasks"))
+def queue_has_count(service: TaskQueueService, count: int) -> None:
+    assert len(service.list_all_tasks()) == count
+
+
+@then(parsers.parse('the task has name "{name}"'))
+def task_has_name(service: TaskQueueService, name: str) -> None:
+    tasks = service.list_all_tasks()
+    assert any(t.name == name for t in tasks)
+
+
+@then(parsers.parse('I receive a validation error containing "{text}"'))
+def got_validation_error(error: ValueError | None, text: str) -> None:
+    assert error is not None
+    assert text in str(error)

--- a/tests/bdd/steps/test_task_edit.py
+++ b/tests/bdd/steps/test_task_edit.py
@@ -1,0 +1,214 @@
+"""Step implementations for task_edit.feature."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pytest_bdd import given, parsers, scenario, then, when
+from tests.conftest import InMemoryTaskRepository
+
+from aihelm.domain.models.status import StatusEnum
+from aihelm.domain.models.task import Task
+from aihelm.infra.persistence.json_task_repository import JsonTaskRepository
+from aihelm.services.task_queue_service import TaskQueueService
+
+# --- Scenarios ---
+
+
+@scenario("../features/task_edit.feature", "Edit the name of a queued task")
+def test_edit_name() -> None:
+    pass
+
+
+@scenario("../features/task_edit.feature", "Edit the prompt of a queued task")
+def test_edit_prompt() -> None:
+    pass
+
+
+@scenario("../features/task_edit.feature", "Edit the branch of a queued task")
+def test_edit_branch() -> None:
+    pass
+
+
+@scenario("../features/task_edit.feature", "Reject editing a running task")
+def test_reject_edit_running() -> None:
+    pass
+
+
+@scenario("../features/task_edit.feature", "Reject duplicate branch on edit")
+def test_reject_duplicate_branch_edit() -> None:
+    pass
+
+
+@scenario("../features/task_edit.feature", "Edited task persists")
+def test_edit_persists() -> None:
+    pass
+
+
+# --- Fixtures ---
+
+
+@pytest.fixture()
+def context() -> dict[str, object]:
+    return {}
+
+
+# --- Given steps ---
+
+
+@given("an empty task queue", target_fixture="service")
+def empty_queue() -> TaskQueueService:
+    return TaskQueueService(repo=InMemoryTaskRepository())
+
+
+@given(
+    parsers.parse(
+        'a running task with name "{name}" prompt "{prompt}" and branch "{branch}"'
+    ),
+    target_fixture="last_task",
+)
+def running_task(
+    service: TaskQueueService, name: str, prompt: str, branch: str
+) -> Task:
+    task = Task(
+        name=name,
+        prompt=prompt,
+        branch_name=branch,
+        status=StatusEnum.RUNNING,
+        position=0,
+    )
+    service._repo.save(task)
+    return task
+
+
+@given("a JSON-backed task queue", target_fixture="service")
+def json_backed_queue(tmp_path: Path, context: dict[str, object]) -> TaskQueueService:
+    path = tmp_path / "tasks.json"
+    context["json_path"] = path
+    repo = JsonTaskRepository(path=path)
+    return TaskQueueService(repo=repo)
+
+
+# --- When steps ---
+
+
+@when(
+    parsers.parse(
+        'I add a task with name "{name}" prompt "{prompt}" and branch "{branch}"'
+    ),
+    target_fixture="last_task",
+)
+def add_task(service: TaskQueueService, name: str, prompt: str, branch: str) -> Task:
+    return service.add_task(name, prompt, branch)
+
+
+@when(
+    parsers.parse('I edit the task name to "{name}"'),
+    target_fixture="last_task",
+)
+def edit_task_name(service: TaskQueueService, last_task: Task, name: str) -> Task:
+    return service.update_task(
+        last_task.id,
+        name=name,
+        prompt=last_task.prompt,
+        branch_name=last_task.branch_name,
+    )
+
+
+@when(
+    parsers.parse('I edit the task prompt to "{prompt}"'),
+    target_fixture="last_task",
+)
+def edit_task_prompt(service: TaskQueueService, last_task: Task, prompt: str) -> Task:
+    return service.update_task(
+        last_task.id,
+        name=last_task.name,
+        prompt=prompt,
+        branch_name=last_task.branch_name,
+    )
+
+
+@when(
+    parsers.parse('I edit the task branch to "{branch}"'),
+    target_fixture="last_task",
+)
+def edit_task_branch(service: TaskQueueService, last_task: Task, branch: str) -> Task:
+    return service.update_task(
+        last_task.id,
+        name=last_task.name,
+        prompt=last_task.prompt,
+        branch_name=branch,
+    )
+
+
+@when(
+    parsers.parse('I try to edit the task name to "{name}"'),
+    target_fixture="error",
+)
+def try_edit_task_name(
+    service: TaskQueueService, last_task: Task, name: str
+) -> ValueError | None:
+    try:
+        service.update_task(
+            last_task.id,
+            name=name,
+            prompt=last_task.prompt,
+            branch_name=last_task.branch_name,
+        )
+    except ValueError as exc:
+        return exc
+    return None
+
+
+@when(
+    parsers.parse('I try to edit task "{task_name}" branch to "{branch}"'),
+    target_fixture="error",
+)
+def try_edit_task_branch(
+    service: TaskQueueService, task_name: str, branch: str
+) -> ValueError | None:
+    tasks = service.list_all_tasks()
+    target = next(t for t in tasks if t.name == task_name)
+    try:
+        service.update_task(
+            target.id,
+            name=target.name,
+            prompt=target.prompt,
+            branch_name=branch,
+        )
+    except ValueError as exc:
+        return exc
+    return None
+
+
+@when("I reload the queue from storage", target_fixture="service")
+def reload_queue(context: dict[str, object]) -> TaskQueueService:
+    path: Path = context["json_path"]  # type: ignore[assignment]
+    repo = JsonTaskRepository(path=path)
+    return TaskQueueService(repo=repo)
+
+
+# --- Then steps ---
+
+
+@then(parsers.parse('the task has name "{name}"'))
+def task_has_name(service: TaskQueueService, name: str) -> None:
+    tasks = service.list_all_tasks()
+    assert any(t.name == name for t in tasks)
+
+
+@then(parsers.parse('the task prompt is "{prompt}"'))
+def task_has_prompt(last_task: Task, prompt: str) -> None:
+    assert last_task.prompt == prompt
+
+
+@then(parsers.parse('the task has branch "{branch}"'))
+def task_has_branch(last_task: Task, branch: str) -> None:
+    assert last_task.branch_name == branch
+
+
+@then(parsers.parse('I receive a validation error containing "{text}"'))
+def got_validation_error(error: ValueError | None, text: str) -> None:
+    assert error is not None
+    assert text in str(error)

--- a/tests/bdd/steps/test_task_queue.py
+++ b/tests/bdd/steps/test_task_queue.py
@@ -1,0 +1,163 @@
+"""Step implementations for task_queue.feature."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pytest_bdd import given, parsers, scenario, then, when
+from tests.conftest import InMemoryTaskRepository
+
+from aihelm.domain.models.task import Task
+from aihelm.infra.persistence.json_task_repository import JsonTaskRepository
+from aihelm.services.task_queue_service import TaskQueueService
+
+# --- Scenarios ---
+
+
+@scenario("../features/task_queue.feature", "Add a valid task to the queue")
+def test_add_valid_task() -> None:
+    pass
+
+
+@scenario("../features/task_queue.feature", "Reject task with invalid branch name")
+def test_reject_invalid_branch() -> None:
+    pass
+
+
+@scenario("../features/task_queue.feature", "Reject task with empty name")
+def test_reject_empty_name() -> None:
+    pass
+
+
+@scenario("../features/task_queue.feature", "Reject duplicate active branch")
+def test_reject_duplicate_branch() -> None:
+    pass
+
+
+@scenario("../features/task_queue.feature", "Tasks are ordered by position")
+def test_task_ordering() -> None:
+    pass
+
+
+@scenario("../features/task_queue.feature", "Tasks persist across restarts")
+def test_persistence() -> None:
+    pass
+
+
+# --- Fixtures ---
+
+
+@pytest.fixture()
+def context() -> dict[str, object]:
+    return {}
+
+
+# --- Given steps ---
+
+
+@given("an empty task queue", target_fixture="service")
+def empty_queue() -> TaskQueueService:
+    return TaskQueueService(repo=InMemoryTaskRepository())
+
+
+@given(
+    parsers.parse('a queued task with branch "{branch}"'),
+    target_fixture="service",
+)
+def queue_with_existing_task(
+    service: TaskQueueService, branch: str
+) -> TaskQueueService:
+    service.add_task("Existing", "p", branch)
+    return service
+
+
+@given("a JSON-backed task queue", target_fixture="service")
+def json_backed_queue(tmp_path: Path, context: dict[str, object]) -> TaskQueueService:
+    path = tmp_path / "tasks.json"
+    context["json_path"] = path
+    repo = JsonTaskRepository(path=path)
+    return TaskQueueService(repo=repo)
+
+
+# --- When steps ---
+
+
+@when(
+    parsers.parse(
+        'I add a task with name "{name}" prompt "{prompt}" and branch "{branch}"'
+    ),
+    target_fixture="last_task",
+)
+def add_task(service: TaskQueueService, name: str, prompt: str, branch: str) -> Task:
+    return service.add_task(name, prompt, branch)
+
+
+@when(
+    parsers.parse(
+        'I try to add a task with name "{name}" prompt "{prompt}" and branch "{branch}"'
+    ),
+    target_fixture="error",
+)
+def try_add_task(
+    service: TaskQueueService, name: str, prompt: str, branch: str
+) -> ValueError | None:
+    try:
+        service.add_task(name, prompt, branch)
+    except ValueError as exc:
+        return exc
+    return None
+
+
+@when("I try to add a task with an empty name", target_fixture="error")
+def try_add_task_empty_name(service: TaskQueueService) -> ValueError | None:
+    try:
+        service.add_task("", "something", "feature/ok")
+    except ValueError as exc:
+        return exc
+    return None
+
+
+@when("I reload the queue from storage", target_fixture="service")
+def reload_queue(context: dict[str, object]) -> TaskQueueService:
+    path: Path = context["json_path"]  # type: ignore[assignment]
+    repo = JsonTaskRepository(path=path)
+    return TaskQueueService(repo=repo)
+
+
+# --- Then steps ---
+
+
+@then(parsers.parse("the queue contains {count:d} task"))
+@then(parsers.parse("the queue contains {count:d} tasks"))
+def queue_has_count(service: TaskQueueService, count: int) -> None:
+    assert len(service.list_queue()) == count
+
+
+@then(parsers.parse('the task has status "{status}"'))
+def task_has_status(last_task: Task, status: str) -> None:
+    assert last_task.status == status
+
+
+@then(parsers.parse('the task has branch "{branch}"'))
+def task_has_branch(last_task: Task, branch: str) -> None:
+    assert last_task.branch_name == branch
+
+
+@then(parsers.parse('the task has name "{name}"'))
+def task_has_name(service: TaskQueueService, name: str) -> None:
+    tasks = service.list_queue()
+    assert any(t.name == name for t in tasks)
+
+
+@then(parsers.parse('I receive a validation error containing "{text}"'))
+def got_validation_error(error: ValueError | None, text: str) -> None:
+    assert error is not None
+    assert text in str(error)
+
+
+@then(parsers.parse('the queue lists "{first}" before "{second}"'))
+def queue_order(service: TaskQueueService, first: str, second: str) -> None:
+    tasks = service.list_queue()
+    names = [t.name for t in tasks]
+    assert names.index(first) < names.index(second)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,44 @@
+"""Shared test fixtures including InMemoryTaskRepository."""
+
+from __future__ import annotations
+
+import pytest
+
+from aihelm.domain.models.status import StatusEnum
+from aihelm.domain.models.task import Task
+from aihelm.domain.ports.task_repository import TaskRepository
+
+
+class InMemoryTaskRepository(TaskRepository):
+    """In-memory fake for testing (no I/O)."""
+
+    def __init__(self) -> None:
+        self._tasks: dict[str, Task] = {}
+
+    def save(self, task: Task) -> None:
+        self._tasks[task.id] = task
+
+    def get(self, task_id: str) -> Task | None:
+        return self._tasks.get(task_id)
+
+    def list_by_status(self, status: StatusEnum) -> list[Task]:
+        return sorted(
+            (t for t in self._tasks.values() if t.status == status),
+            key=lambda t: t.position,
+        )
+
+    def list_all(self) -> list[Task]:
+        return sorted(self._tasks.values(), key=lambda t: t.position)
+
+    def delete(self, task_id: str) -> None:
+        self._tasks.pop(task_id, None)
+
+    def next_position(self) -> int:
+        if not self._tasks:
+            return 0
+        return max(t.position for t in self._tasks.values()) + 1
+
+
+@pytest.fixture()
+def in_memory_repo() -> InMemoryTaskRepository:
+    return InMemoryTaskRepository()

--- a/tests/unit/domain/test_status.py
+++ b/tests/unit/domain/test_status.py
@@ -1,0 +1,24 @@
+from aihelm.domain.models.status import StatusEnum
+
+
+class TestStatusEnum:
+    def test_has_five_members(self) -> None:
+        assert len(StatusEnum) == 5
+
+    def test_queued_value(self) -> None:
+        assert StatusEnum.QUEUED == "queued"
+
+    def test_running_value(self) -> None:
+        assert StatusEnum.RUNNING == "running"
+
+    def test_paused_value(self) -> None:
+        assert StatusEnum.PAUSED == "paused"
+
+    def test_done_value(self) -> None:
+        assert StatusEnum.DONE == "done"
+
+    def test_failed_value(self) -> None:
+        assert StatusEnum.FAILED == "failed"
+
+    def test_is_str_subclass(self) -> None:
+        assert isinstance(StatusEnum.QUEUED, str)

--- a/tests/unit/domain/test_task.py
+++ b/tests/unit/domain/test_task.py
@@ -1,0 +1,101 @@
+import uuid
+from dataclasses import FrozenInstanceError
+from datetime import UTC, datetime
+
+import pytest
+
+from aihelm.domain.models.status import StatusEnum
+from aihelm.domain.models.task import Task
+
+
+class TestTaskCreation:
+    def test_defaults(self) -> None:
+        task = Task(name="Fix bug", prompt="Fix it", branch_name="feature/fix")
+        assert task.status == StatusEnum.QUEUED
+        assert task.position == 0
+        assert isinstance(task.created_at, datetime)
+        uuid.UUID(task.id)  # validates it's a valid UUID
+
+    def test_explicit_fields(self) -> None:
+        dt = datetime(2026, 1, 1, tzinfo=UTC)
+        task = Task(
+            name="Test",
+            prompt="Do it",
+            branch_name="fix/test",
+            id="abc-123",
+            status=StatusEnum.RUNNING,
+            created_at=dt,
+            position=5,
+        )
+        assert task.id == "abc-123"
+        assert task.status == StatusEnum.RUNNING
+        assert task.created_at == dt
+        assert task.position == 5
+
+    def test_frozen(self) -> None:
+        task = Task(name="X", prompt="Y", branch_name="feature/x")
+        with pytest.raises(FrozenInstanceError):
+            task.name = "Z"  # type: ignore[misc]
+
+
+class TestTaskNameValidation:
+    def test_empty_name_rejected(self) -> None:
+        with pytest.raises(ValueError, match="name"):
+            Task(name="", prompt="p", branch_name="feature/ok")
+
+    def test_max_length_accepted(self) -> None:
+        task = Task(name="a" * 200, prompt="p", branch_name="feature/ok")
+        assert len(task.name) == 200
+
+    def test_over_max_length_rejected(self) -> None:
+        with pytest.raises(ValueError, match="name"):
+            Task(name="a" * 201, prompt="p", branch_name="feature/ok")
+
+
+class TestPromptValidation:
+    def test_empty_prompt_rejected(self) -> None:
+        with pytest.raises(ValueError, match="Prompt"):
+            Task(name="X", prompt="", branch_name="feature/ok")
+
+
+class TestBranchNameValidation:
+    @pytest.mark.parametrize(
+        "branch",
+        [
+            "feature/ok",
+            "fix/bug-123",
+            "feature/a/b/c",
+            "my-branch",
+            "release/v1.0.0",
+            "feat/CAPS-ok",
+        ],
+    )
+    def test_valid_names(self, branch: str) -> None:
+        task = Task(name="T", prompt="P", branch_name=branch)
+        assert task.branch_name == branch
+
+    @pytest.mark.parametrize(
+        ("branch", "reason"),
+        [
+            ("feature/bad name", "space"),
+            ("feature/a..b", "double dot"),
+            ("feature/@{ref}", "at-brace"),
+            (".hidden", "leading dot"),
+            ("feature/end.", "trailing dot"),
+            ("feature/main.lock", ".lock suffix"),
+            ("feature/a~1", "tilde"),
+            ("feature\\name", "backslash"),
+            ("feature/a^b", "caret"),
+            ("feature/a:b", "colon"),
+            ("feature/a?b", "question mark"),
+            ("feature/a*b", "asterisk"),
+            ("feature/a[b", "bracket"),
+            ("-leading-dash", "leading dash"),
+            ("feature/trailing/", "trailing slash"),
+            ("feature//double", "consecutive slashes"),
+            ("@", "bare at"),
+        ],
+    )
+    def test_invalid_names(self, branch: str, reason: str) -> None:
+        with pytest.raises(ValueError, match="Invalid git branch name"):
+            Task(name="T", prompt="P", branch_name=branch)

--- a/tests/unit/infra/test_json_task_repository.py
+++ b/tests/unit/infra/test_json_task_repository.py
@@ -1,0 +1,129 @@
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from aihelm.domain.models.status import StatusEnum
+from aihelm.domain.models.task import Task
+from aihelm.infra.persistence.json_task_repository import JsonTaskRepository
+
+
+def _make_task(
+    *,
+    name: str = "Test",
+    prompt: str = "Do it",
+    branch: str = "feature/test",
+    position: int = 0,
+    status: StatusEnum = StatusEnum.QUEUED,
+    task_id: str = "test-id",
+) -> Task:
+    return Task(
+        name=name,
+        prompt=prompt,
+        branch_name=branch,
+        id=task_id,
+        status=status,
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        position=position,
+    )
+
+
+@pytest.fixture()
+def repo(tmp_path: Path) -> JsonTaskRepository:
+    return JsonTaskRepository(path=tmp_path / "tasks.json")
+
+
+class TestSaveAndGet:
+    def test_roundtrip(self, repo: JsonTaskRepository) -> None:
+        task = _make_task()
+        repo.save(task)
+        got = repo.get(task.id)
+        assert got is not None
+        assert got.id == task.id
+        assert got.name == task.name
+        assert got.prompt == task.prompt
+        assert got.branch_name == task.branch_name
+        assert got.status == task.status
+        assert got.position == task.position
+
+    def test_upsert_replaces(self, repo: JsonTaskRepository) -> None:
+        task = _make_task()
+        repo.save(task)
+        updated = Task(
+            name="Updated",
+            prompt=task.prompt,
+            branch_name=task.branch_name,
+            id=task.id,
+            status=StatusEnum.RUNNING,
+            created_at=task.created_at,
+            position=task.position,
+        )
+        repo.save(updated)
+        got = repo.get(task.id)
+        assert got is not None
+        assert got.name == "Updated"
+        assert got.status == StatusEnum.RUNNING
+
+
+class TestListAll:
+    def test_sorted_by_position(self, repo: JsonTaskRepository) -> None:
+        repo.save(_make_task(position=2, task_id="b", branch="feature/b"))
+        repo.save(_make_task(position=0, task_id="a", branch="feature/a"))
+        repo.save(_make_task(position=1, task_id="c", branch="feature/c"))
+        tasks = repo.list_all()
+        assert [t.position for t in tasks] == [0, 1, 2]
+
+    def test_empty_repo(self, repo: JsonTaskRepository) -> None:
+        assert repo.list_all() == []
+
+
+class TestListByStatus:
+    def test_filters_correctly(self, repo: JsonTaskRepository) -> None:
+        repo.save(_make_task(task_id="a", branch="feature/a", status=StatusEnum.QUEUED))
+        repo.save(
+            _make_task(task_id="b", branch="feature/b", status=StatusEnum.RUNNING),
+        )
+        queued = repo.list_by_status(StatusEnum.QUEUED)
+        assert len(queued) == 1
+        assert queued[0].id == "a"
+
+
+class TestDelete:
+    def test_removes_task(self, repo: JsonTaskRepository) -> None:
+        task = _make_task()
+        repo.save(task)
+        repo.delete(task.id)
+        assert repo.get(task.id) is None
+
+    def test_nonexistent_is_noop(self, repo: JsonTaskRepository) -> None:
+        repo.delete("does-not-exist")  # should not raise
+
+
+class TestNextPosition:
+    def test_empty_returns_zero(self, repo: JsonTaskRepository) -> None:
+        assert repo.next_position() == 0
+
+    def test_after_saves(self, repo: JsonTaskRepository) -> None:
+        repo.save(_make_task(position=3, task_id="a", branch="feature/a"))
+        repo.save(_make_task(position=7, task_id="b", branch="feature/b"))
+        assert repo.next_position() == 8
+
+
+class TestFileIntegrity:
+    def test_creates_parent_dirs(self, tmp_path: Path) -> None:
+        deep = tmp_path / "a" / "b" / "tasks.json"
+        repo = JsonTaskRepository(path=deep)
+        repo.save(_make_task())
+        assert deep.exists()
+
+    def test_json_is_valid(self, repo: JsonTaskRepository, tmp_path: Path) -> None:
+        repo.save(_make_task())
+        raw = (tmp_path / "tasks.json").read_text(encoding="utf-8")
+        data = json.loads(raw)
+        assert isinstance(data, list)
+        assert len(data) == 1
+
+    def test_missing_file_returns_empty(self, repo: JsonTaskRepository) -> None:
+        assert repo.list_all() == []
+        assert repo.get("x") is None

--- a/tests/unit/services/test_task_queue_service.py
+++ b/tests/unit/services/test_task_queue_service.py
@@ -1,0 +1,90 @@
+import pytest
+from tests.conftest import InMemoryTaskRepository
+
+from aihelm.domain.models.status import StatusEnum
+from aihelm.domain.models.task import Task
+from aihelm.services.task_queue_service import TaskQueueService
+
+
+@pytest.fixture()
+def repo() -> InMemoryTaskRepository:
+    return InMemoryTaskRepository()
+
+
+@pytest.fixture()
+def service(repo: InMemoryTaskRepository) -> TaskQueueService:
+    return TaskQueueService(repo=repo)
+
+
+class TestAddTask:
+    def test_returns_queued_task(self, service: TaskQueueService) -> None:
+        task = service.add_task("Fix bug", "Fix it", "feature/fix")
+        assert task.status == StatusEnum.QUEUED
+        assert task.name == "Fix bug"
+
+    def test_auto_assigns_position(self, service: TaskQueueService) -> None:
+        t1 = service.add_task("First", "p1", "feature/first")
+        t2 = service.add_task("Second", "p2", "feature/second")
+        assert t1.position == 0
+        assert t2.position == 1
+
+    def test_rejects_duplicate_active_branch(self, service: TaskQueueService) -> None:
+        service.add_task("First", "p", "feature/dup")
+        with pytest.raises(ValueError, match="already assigned"):
+            service.add_task("Second", "p", "feature/dup")
+
+    def test_allows_branch_reuse_after_done(
+        self, repo: InMemoryTaskRepository, service: TaskQueueService
+    ) -> None:
+        done_task = Task(
+            name="Old",
+            prompt="p",
+            branch_name="feature/reuse",
+            status=StatusEnum.DONE,
+            position=0,
+        )
+        repo.save(done_task)
+        task = service.add_task("New", "p", "feature/reuse")
+        assert task.branch_name == "feature/reuse"
+
+    def test_delegates_validation_to_task(self, service: TaskQueueService) -> None:
+        with pytest.raises(ValueError, match="Invalid git branch name"):
+            service.add_task("X", "p", "feature/bad name")
+
+
+class TestListQueue:
+    def test_returns_only_queued(
+        self, repo: InMemoryTaskRepository, service: TaskQueueService
+    ) -> None:
+        service.add_task("Queued", "p", "feature/q")
+        running_task = Task(
+            name="Running",
+            prompt="p",
+            branch_name="feature/r",
+            status=StatusEnum.RUNNING,
+            position=1,
+        )
+        repo.save(running_task)
+        queue = service.list_queue()
+        assert len(queue) == 1
+        assert queue[0].name == "Queued"
+
+    def test_empty_queue(self, service: TaskQueueService) -> None:
+        assert service.list_queue() == []
+
+
+class TestListAllTasks:
+    def test_returns_all_statuses(
+        self, repo: InMemoryTaskRepository, service: TaskQueueService
+    ) -> None:
+        service.add_task("Queued", "p", "feature/q")
+        done_task = Task(
+            name="Done",
+            prompt="p",
+            branch_name="feature/d",
+            status=StatusEnum.DONE,
+            position=1,
+        )
+        repo.save(done_task)
+        all_tasks = service.list_all_tasks()
+        assert len(all_tasks) == 2

--- a/tests/unit/services/test_task_queue_service.py
+++ b/tests/unit/services/test_task_queue_service.py
@@ -240,6 +240,82 @@ class TestUpdateTask:
         assert stored.name == "New"
 
 
+class TestDeleteTask:
+    def test_deletes_queued_task(
+        self, repo: InMemoryTaskRepository, service: TaskQueueService
+    ) -> None:
+        task = service.add_task("T", "p", "feature/x")
+        service.delete_task(task.id)
+        assert repo.get(task.id) is None
+
+    def test_deletes_paused_task(
+        self, repo: InMemoryTaskRepository, service: TaskQueueService
+    ) -> None:
+        task = Task(
+            name="P",
+            prompt="p",
+            branch_name="feature/p",
+            status=StatusEnum.PAUSED,
+            position=0,
+        )
+        repo.save(task)
+        service.delete_task(task.id)
+        assert repo.get(task.id) is None
+
+    def test_deletes_done_task(
+        self, repo: InMemoryTaskRepository, service: TaskQueueService
+    ) -> None:
+        task = Task(
+            name="D",
+            prompt="p",
+            branch_name="feature/d",
+            status=StatusEnum.DONE,
+            position=0,
+        )
+        repo.save(task)
+        service.delete_task(task.id)
+        assert repo.get(task.id) is None
+
+    def test_deletes_failed_task(
+        self, repo: InMemoryTaskRepository, service: TaskQueueService
+    ) -> None:
+        task = Task(
+            name="F",
+            prompt="p",
+            branch_name="feature/f",
+            status=StatusEnum.FAILED,
+            position=0,
+        )
+        repo.save(task)
+        service.delete_task(task.id)
+        assert repo.get(task.id) is None
+
+    def test_rejects_deleting_running_task(
+        self, repo: InMemoryTaskRepository, service: TaskQueueService
+    ) -> None:
+        task = Task(
+            name="R",
+            prompt="p",
+            branch_name="feature/r",
+            status=StatusEnum.RUNNING,
+            position=0,
+        )
+        repo.save(task)
+        with pytest.raises(ValueError, match="Cannot delete a running task"):
+            service.delete_task(task.id)
+        assert repo.get(task.id) is not None
+
+    def test_rejects_deleting_nonexistent_task(self, service: TaskQueueService) -> None:
+        with pytest.raises(ValueError, match="Task not found"):
+            service.delete_task("nonexistent-id")
+
+    def test_releases_branch_for_reuse(self, service: TaskQueueService) -> None:
+        task = service.add_task("T", "p", "feature/reuse")
+        service.delete_task(task.id)
+        new_task = service.add_task("T2", "p2", "feature/reuse")
+        assert new_task.branch_name == "feature/reuse"
+
+
 class TestListAllTasks:
     def test_returns_all_statuses(
         self, repo: InMemoryTaskRepository, service: TaskQueueService

--- a/tests/unit/services/test_task_queue_service.py
+++ b/tests/unit/services/test_task_queue_service.py
@@ -73,6 +73,173 @@ class TestListQueue:
         assert service.list_queue() == []
 
 
+class TestUpdateTask:
+    def test_updates_name(
+        self, repo: InMemoryTaskRepository, service: TaskQueueService
+    ) -> None:
+        task = service.add_task("Old", "p", "feature/x")
+        updated = service.update_task(
+            task.id, name="New", prompt="p", branch_name="feature/x"
+        )
+        assert updated.name == "New"
+        assert updated.id == task.id
+        assert updated.created_at == task.created_at
+        assert updated.position == task.position
+
+    def test_updates_prompt(
+        self, repo: InMemoryTaskRepository, service: TaskQueueService
+    ) -> None:
+        task = service.add_task("T", "old prompt", "feature/x")
+        updated = service.update_task(
+            task.id, name="T", prompt="new prompt", branch_name="feature/x"
+        )
+        assert updated.prompt == "new prompt"
+
+    def test_updates_branch_name(
+        self, repo: InMemoryTaskRepository, service: TaskQueueService
+    ) -> None:
+        task = service.add_task("T", "p", "feature/old")
+        updated = service.update_task(
+            task.id, name="T", prompt="p", branch_name="feature/new"
+        )
+        assert updated.branch_name == "feature/new"
+
+    def test_updates_multiple_fields(
+        self, repo: InMemoryTaskRepository, service: TaskQueueService
+    ) -> None:
+        task = service.add_task("A", "pa", "feature/a")
+        updated = service.update_task(
+            task.id, name="B", prompt="pb", branch_name="feature/b"
+        )
+        assert updated.name == "B"
+        assert updated.prompt == "pb"
+        assert updated.branch_name == "feature/b"
+
+    def test_rejects_nonexistent_task(self, service: TaskQueueService) -> None:
+        with pytest.raises(ValueError, match="Task not found"):
+            service.update_task(
+                "nonexistent-id", name="X", prompt="p", branch_name="feature/x"
+            )
+
+    def test_rejects_edit_of_running_task(
+        self, repo: InMemoryTaskRepository, service: TaskQueueService
+    ) -> None:
+        task = Task(
+            name="R",
+            prompt="p",
+            branch_name="feature/r",
+            status=StatusEnum.RUNNING,
+            position=0,
+        )
+        repo.save(task)
+        with pytest.raises(ValueError, match="Only queued tasks can be edited"):
+            service.update_task(
+                task.id, name="New", prompt="p", branch_name="feature/r"
+            )
+
+    def test_rejects_edit_of_done_task(
+        self, repo: InMemoryTaskRepository, service: TaskQueueService
+    ) -> None:
+        task = Task(
+            name="D",
+            prompt="p",
+            branch_name="feature/d",
+            status=StatusEnum.DONE,
+            position=0,
+        )
+        repo.save(task)
+        with pytest.raises(ValueError, match="Only queued tasks can be edited"):
+            service.update_task(
+                task.id, name="New", prompt="p", branch_name="feature/d"
+            )
+
+    def test_rejects_edit_of_failed_task(
+        self, repo: InMemoryTaskRepository, service: TaskQueueService
+    ) -> None:
+        task = Task(
+            name="F",
+            prompt="p",
+            branch_name="feature/f",
+            status=StatusEnum.FAILED,
+            position=0,
+        )
+        repo.save(task)
+        with pytest.raises(ValueError, match="Only queued tasks can be edited"):
+            service.update_task(
+                task.id, name="New", prompt="p", branch_name="feature/f"
+            )
+
+    def test_rejects_edit_of_paused_task(
+        self, repo: InMemoryTaskRepository, service: TaskQueueService
+    ) -> None:
+        task = Task(
+            name="P",
+            prompt="p",
+            branch_name="feature/p",
+            status=StatusEnum.PAUSED,
+            position=0,
+        )
+        repo.save(task)
+        with pytest.raises(ValueError, match="Only queued tasks can be edited"):
+            service.update_task(
+                task.id, name="New", prompt="p", branch_name="feature/p"
+            )
+
+    def test_rejects_duplicate_branch_on_edit(self, service: TaskQueueService) -> None:
+        service.add_task("A", "p", "feature/a")
+        task_b = service.add_task("B", "p", "feature/b")
+        with pytest.raises(ValueError, match="already assigned"):
+            service.update_task(
+                task_b.id, name="B", prompt="p", branch_name="feature/a"
+            )
+
+    def test_allows_keeping_same_branch(self, service: TaskQueueService) -> None:
+        task = service.add_task("T", "p", "feature/keep")
+        updated = service.update_task(
+            task.id, name="New Name", prompt="p", branch_name="feature/keep"
+        )
+        assert updated.branch_name == "feature/keep"
+        assert updated.name == "New Name"
+
+    def test_allows_branch_reuse_from_done_task(
+        self, repo: InMemoryTaskRepository, service: TaskQueueService
+    ) -> None:
+        done_task = Task(
+            name="Done",
+            prompt="p",
+            branch_name="feature/reuse",
+            status=StatusEnum.DONE,
+            position=0,
+        )
+        repo.save(done_task)
+        task = service.add_task("Active", "p", "feature/active")
+        updated = service.update_task(
+            task.id, name="Active", prompt="p", branch_name="feature/reuse"
+        )
+        assert updated.branch_name == "feature/reuse"
+
+    def test_validates_name_on_edit(self, service: TaskQueueService) -> None:
+        task = service.add_task("T", "p", "feature/x")
+        with pytest.raises(ValueError, match="name"):
+            service.update_task(task.id, name="", prompt="p", branch_name="feature/x")
+
+    def test_validates_branch_on_edit(self, service: TaskQueueService) -> None:
+        task = service.add_task("T", "p", "feature/x")
+        with pytest.raises(ValueError, match="Invalid git branch name"):
+            service.update_task(
+                task.id, name="T", prompt="p", branch_name="feature/bad name"
+            )
+
+    def test_persists_changes(
+        self, repo: InMemoryTaskRepository, service: TaskQueueService
+    ) -> None:
+        task = service.add_task("Old", "p", "feature/x")
+        service.update_task(task.id, name="New", prompt="p", branch_name="feature/x")
+        stored = repo.get(task.id)
+        assert stored is not None
+        assert stored.name == "New"
+
+
 class TestListAllTasks:
     def test_returns_all_statuses(
         self, repo: InMemoryTaskRepository, service: TaskQueueService


### PR DESCRIPTION
## Summary

Adds task editing and deletion functionality to AIHelm. Users can now click a task in the sidebar to view its details in the right panel, edit the fields (name, prompt, branch) of queued tasks, and delete any non-running task with a confirmation dialog. Follows the SDD workflow: specs first, then service layer, then UI, then tests.  

## Changes

- Added update_task() and delete_task() methods to TaskQueueService
- Created TaskDetailView component for the right panel with view/edit modes
- Added click handler to TaskCard and on_task_selected callback to QueueView                                                                
- Wired TaskDetailView into __main__.py, replacing the placeholder right panel                                                              
- Added delete confirmation dialog (AlertDialog) for destructive action safety                                                              
- Edit restricted to QUEUED tasks only; delete restricted to non-RUNNING tasks  

## Specs Updated

- [x] `specs/contracts/` updated (if ports changed)
- [x] `specs/schemas/` updated (if models changed)
- [x] `specs/rules/` updated (if business logic changed)
- [ ] N/A — no spec changes needed

## Testing

- [x] Unit tests added/updated
- [x] BDD scenarios added/updated (if new behavior)
- [ ] Integration tests added/updated (if I/O changed)
- [x] All tests pass locally (`pytest`)

## Architecture

- [x] Layer boundaries respected (domain has no outer imports)
- [x] New ports use dependency injection
- [x] No direct infra imports from services/ui
